### PR TITLE
Fix g10 jump

### DIFF
--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -415,6 +415,10 @@ void  G10(String readString){
 
 /*The G10() function handles the G10 gcode which re-zeroes one or all of the machine's axes.*/
     
+    leftAxis.detach();
+    rightAxis.detach();
+    zAxis.detach();
+    
     leftAxis.set(0);
     rightAxis.set(0);
     zAxis.set(0);
@@ -422,6 +426,8 @@ void  G10(String readString){
     leftAxis.endMove(0);
     rightAxis.endMove(0);
     zAxis.endMove(0);
+    
+    delay(1000); //Let the PID controller settle 
     
     leftAxis.attach();
     rightAxis.attach();

--- a/cnc_ctrl_v1/GearMotor.cpp
+++ b/cnc_ctrl_v1/GearMotor.cpp
@@ -53,7 +53,7 @@ int  GearMotor::setupMotor(int pwmPin, int pin1, int pin2){
   return 1;
 }
 
-void GearMotor::attach(int pin){
+void GearMotor::attach(){
     _attachedState = 1;
 }
 

--- a/cnc_ctrl_v1/GearMotor.h
+++ b/cnc_ctrl_v1/GearMotor.h
@@ -34,7 +34,7 @@
     class GearMotor{
         public:
             GearMotor();
-            void attach(int pin);
+            void attach();
             int  setupMotor(int pwmPin, int pin1, int pin2);
             void detach();
             void write(int speed);

--- a/cnc_ctrl_v1/axis.cpp
+++ b/cnc_ctrl_v1/axis.cpp
@@ -94,6 +94,9 @@ float  Axis::setpoint(){
 int    Axis::set(float newAxisPosition){
     _axisTarget   =  newAxisPosition/_mmPerRotation;
     _encoder.write((newAxisPosition*NUMBER_OF_ENCODER_STEPS)/_mmPerRotation);
+    
+    Serial.println("set to :");
+    Serial.println(_encoder.read());
 }
 
 void   Axis::computePID(){
@@ -148,7 +151,7 @@ int    Axis::detach(){
 }
 
 int    Axis::attach(){
-     _motor.attach(1);
+     _motor.attach();
      return 1;
 }
 

--- a/cnc_ctrl_v1/axis.cpp
+++ b/cnc_ctrl_v1/axis.cpp
@@ -92,11 +92,12 @@ float  Axis::setpoint(){
 }
 
 int    Axis::set(float newAxisPosition){
+    
+    //reset everything to the new value
     _axisTarget   =  newAxisPosition/_mmPerRotation;
+    _pidSetpoint  =  newAxisPosition/_mmPerRotation;
     _encoder.write((newAxisPosition*NUMBER_OF_ENCODER_STEPS)/_mmPerRotation);
     
-    Serial.println("set to :");
-    Serial.println(_encoder.read());
 }
 
 void   Axis::computePID(){


### PR DESCRIPTION
When reseting the origin, the derivitive term of the PID controler would cause the machine to twitch. Adding a delay to let it settle fixed the issue.