### PR TITLE
always prompt, even for tool T1

### DIFF
--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -582,11 +582,9 @@ void  interpretCommandString(String readString){
     }
     
     if((readString[0] == 'T' || readString[0] == 't') && readString[1] != 'e'){
-        if(readString[1] != '1'){
-            Serial.print("Please insert tool ");
-            Serial.println(readString);
-            Serial.println("gready");
-        }
+        Serial.print("Please insert tool ");
+        Serial.println(readString);
+        Serial.println("gready");
         readString = "";
     }
     


### PR DESCRIPTION
This is possibly not the best behavior, maybe T1 should be ignored? But
what if you want to switch back to T1 later in the program. You might
end up skipping a valid tool change