### PR TITLE
set baud rate back

### DIFF
--- a/cnc_ctrl_v1/cnc_ctrl_v1.ino
+++ b/cnc_ctrl_v1/cnc_ctrl_v1.ino
@@ -20,7 +20,7 @@
 String readString;
 
 void setup(){
-    Serial.begin(115200);
+    Serial.begin(19200);
     
     Serial.println("ready");
     Serial.println("gready");


### PR DESCRIPTION
The higher baudrate is droping charicters. I'm not sure why, but 19200 was very stable so I'm going back to it until I can figure out where my letters are going