### PR TITLE
Remove old forward kinematics

### DIFF
--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -83,6 +83,11 @@ float xTarget = 0;
 float yTarget = 0;
 
 void  returnPoz(float x, float y, float z){
+    /*
+    Causes the machine's position (x,y) to be sent over the serial connection updated on the UI
+    in Ground Control. Only executes if hasn't been called in at least timeout ms.
+    */
+    
     static unsigned long lastRan = millis();
     int                  timeout = 200;
     
@@ -662,7 +667,7 @@ void  interpretCommandString(String readString){
     }
     
     if(readString.substring(0, 3) == "B04"){
-        //Test each of the axies
+        //Test each of the axis
         delay(500);
         leftAxis.test();
         delay(500);

--- a/cnc_ctrl_v1/Kinematics.cpp
+++ b/cnc_ctrl_v1/Kinematics.cpp
@@ -23,27 +23,9 @@ in X-Y space.
 #include "Arduino.h"
 #include "Kinematics.h"
 
-#define SLEDWIDTH        310.0
-#define SLEDHEIGHT       139.0
 
 Kinematics::Kinematics(){
     
-}
-
-void  Kinematics::forward(float Lac, float Lbd, float* X, float* Y){
-    //Compute xy position from chain lengths
-    #define SLEDDIAGONAL  sqrt(sq(SLEDHEIGHT) + sq(SLEDWIDTH/2))
-    
-    //Use the law of cosines to find the angle between the two chains
-    float   a   = Lbd;// + SLEDDIAGONAL;
-    float   b   = Lac;// + SLEDDIAGONAL;
-    float   c   = machineWidth+2*motorOffsetX;
-    
-    //Theta is the angle made by the chain and the top left motor
-    float theta = acos( ( sq(b) + sq(c) - sq(a) ) / (2.0*b*c) );
-    
-    *Y   = (machineHeight/2 + motorOffsetY) - (b*sin(theta) + 394); //394 is a made up number to make things look good because this is fake math
-    *X   = (b*cos(theta)) - (machineWidth/2.0 + motorOffsetX);
 }
 
 void Kinematics::_verifyValidTarget(float* xTarget,float* yTarget){

--- a/cnc_ctrl_v1/Kinematics.h
+++ b/cnc_ctrl_v1/Kinematics.h
@@ -26,7 +26,6 @@
     class Kinematics{
         public:
             Kinematics();
-            void  forward   (float chainALength, float chainBLength, float* X, float* Y);
             void  inverse   (float xTarget,float yTarget, float* aChainLength, float* bChainLength);
             void  recomputeGeometry();
             //geometry

--- a/cnc_ctrl_v1/cnc_ctrl_v1.ino
+++ b/cnc_ctrl_v1/cnc_ctrl_v1.ino
@@ -30,8 +30,6 @@ void setup(){
     Timer1.initialize(10000);
     Timer1.attachInterrupt(runsOnATimer);
     
-    kinematics.forward(leftAxis.setpoint(), rightAxis.setpoint(), &xTarget, &yTarget); //setup the targets to be correct
-    
 }
 
 void runsOnATimer(){


### PR DESCRIPTION
The forward kinematics used on startup to determine the machine's position were a flawed approximation. This was causing the position unresolved error. Rather than patch the already flawed approximation I simply removed it which seems like a more honest good practice thing to do. We may see some strange behavior where the machine shows a very large positional error on startup if it is not returned to home before shutting down, but at least it's honest.