### PR TITLE
Switch to measuring the distance between the motors

### DIFF
--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -580,6 +580,7 @@ void  updateSettings(String readString){
     
     if (distBetweenMotors == 0){
         distBetweenMotors = bedWidth + 2*motorOffsetX;
+        Serial.println("Using Old Measuring Method - Consider Updating Ground Control");
     }
     
     //Change the machine dimensions in the kinematics 

--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -537,6 +537,13 @@ void  setInchesToMillimetersConversion(float newConversionFactor){
     _inchesToMMConversion = newConversionFactor;
 }
 
+void  printBeforeAndAfter(float before, float after){
+    Serial.print("Before: ");
+    Serial.print(before);
+    Serial.print(" After: ");
+    Serial.println(after);
+}
+
 void  updateSettings(String readString){
     /*
     Updates the machine dimensions from the Ground Control settings
@@ -553,13 +560,21 @@ void  updateSettings(String readString){
     
     
     //Change the machine dimensions in the kinematics 
+    printBeforeAndAfter(kinematics.l, sledWidth);
     kinematics.l            = sledWidth;
+    printBeforeAndAfter(kinematics.s, sledHeight);
     kinematics.s            = sledHeight;
+    printBeforeAndAfter(kinematics.h3, sledCG);
     kinematics.h3           = sledCG;
+    printBeforeAndAfter(kinematics.D, bedWidth+2*motorOffsetX);
     kinematics.D            = bedWidth+2*motorOffsetX;
+    printBeforeAndAfter(kinematics.motorOffsetX, motorOffsetX);
     kinematics.motorOffsetX = motorOffsetX;
+    printBeforeAndAfter(kinematics.motorOffsetY, motorOffsetY);
     kinematics.motorOffsetY = motorOffsetY;
+    printBeforeAndAfter(kinematics.machineWidth, bedWidth);
     kinematics.machineWidth = bedWidth;
+    printBeforeAndAfter(kinematics.machineHeight, bedHeight);
     kinematics.machineHeight= bedHeight;
     kinematics.recomputeGeometry();
     

--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -561,21 +561,13 @@ void  updateSettings(String readString){
     
     
     //Change the machine dimensions in the kinematics 
-    printBeforeAndAfter(kinematics.l, sledWidth);
     kinematics.l            = sledWidth;
-    printBeforeAndAfter(kinematics.s, sledHeight);
     kinematics.s            = sledHeight;
-    printBeforeAndAfter(kinematics.h3, sledCG);
     kinematics.h3           = sledCG;
-    printBeforeAndAfter(kinematics.D, distBetweenMotors);
     kinematics.D            = distBetweenMotors;
-    printBeforeAndAfter(kinematics.motorOffsetX, motorOffsetX);
     kinematics.motorOffsetX = motorOffsetX;
-    printBeforeAndAfter(kinematics.motorOffsetY, motorOffsetY);
     kinematics.motorOffsetY = motorOffsetY;
-    printBeforeAndAfter(kinematics.machineWidth, bedWidth);
     kinematics.machineWidth = bedWidth;
-    printBeforeAndAfter(kinematics.machineHeight, bedHeight);
     kinematics.machineHeight= bedHeight;
     kinematics.recomputeGeometry();
     

--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -550,13 +550,14 @@ void  updateSettings(String readString){
     */
     
     //Extract the settings values
-    float bedWidth      = extractGcodeValue(readString, 'A', 0);
-    float bedHeight     = extractGcodeValue(readString, 'C', 0);
-    float motorOffsetX  = extractGcodeValue(readString, 'D', 0);
-    float motorOffsetY  = extractGcodeValue(readString, 'E', 0);
-    float sledWidth     = extractGcodeValue(readString, 'F', 0);
-    float sledHeight    = extractGcodeValue(readString, 'G', 0);
-    float sledCG        = extractGcodeValue(readString, 'H', 0);
+    float bedWidth           = extractGcodeValue(readString, 'A', 0);
+    float bedHeight          = extractGcodeValue(readString, 'C', 0);
+    float distBetweenMotors  = extractGcodeValue(readString, 'D', 0);
+    float motorOffsetX       = (distBetweenMotors - bedWidth)/2;
+    float motorOffsetY       = extractGcodeValue(readString, 'E', 0);
+    float sledWidth          = extractGcodeValue(readString, 'F', 0);
+    float sledHeight         = extractGcodeValue(readString, 'G', 0);
+    float sledCG             = extractGcodeValue(readString, 'H', 0);
     
     
     //Change the machine dimensions in the kinematics 
@@ -566,8 +567,8 @@ void  updateSettings(String readString){
     kinematics.s            = sledHeight;
     printBeforeAndAfter(kinematics.h3, sledCG);
     kinematics.h3           = sledCG;
-    printBeforeAndAfter(kinematics.D, bedWidth+2*motorOffsetX);
-    kinematics.D            = bedWidth+2*motorOffsetX;
+    printBeforeAndAfter(kinematics.D, distBetweenMotors);
+    kinematics.D            = distBetweenMotors;
     printBeforeAndAfter(kinematics.motorOffsetX, motorOffsetX);
     kinematics.motorOffsetX = motorOffsetX;
     printBeforeAndAfter(kinematics.motorOffsetY, motorOffsetY);

--- a/cnc_ctrl_v1/Kinematics.cpp
+++ b/cnc_ctrl_v1/Kinematics.cpp
@@ -64,8 +64,8 @@ void  Kinematics::inverse(float xTarget,float yTarget, float* aChainLength, floa
     _verifyValidTarget(&xTarget, &yTarget);
     
     //coordinate shift to put (0,0) in the center of the plywood from the left sprocket
-    x = ( machineWidth/2 - xTarget) + motorOffsetX;
-    y = (machineHeight/2 - yTarget) + motorOffsetY;
+    x = machineWidth/2 + motorOffsetX + xTarget;
+    y = machineHeight/2 + motorOffsetY  - yTarget;
     
     //Coordinates definition:
     //         x -->, y |

--- a/cnc_ctrl_v1/Kinematics.cpp
+++ b/cnc_ctrl_v1/Kinematics.cpp
@@ -175,8 +175,8 @@ void  Kinematics::inverse(float xTarget,float yTarget, float* aChainLength, floa
         Chain2 = sqrt((D - (x + Offsetx2))*(D - (x + Offsetx2))+(y + Y2Plus - Offsety2)*(y + Y2Plus - Offsety2)) - R * TanLambda + R * Lambda;   //right chain length
     }
      
-    *aChainLength = Chain2;
-    *bChainLength = Chain1;
+    *aChainLength = Chain1;
+    *bChainLength = Chain2;
 
 }
 


### PR DESCRIPTION
Switch to using the distance between the motors to do math instead of motor distance from corner of wood. Clean up some internal calculations along the way.

Needs to be merged at the same time as the similar change in Ground Control