### PR TITLE
Add watchdog

### DIFF
--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -116,6 +116,24 @@ void  returnPoz(float x, float y, float z){
     
 }
 
+void  _watchDog(){
+    /*
+    Watchdog tells ground control that the machine is ready every second. _watchDog() should only be called when 
+    the machine is actually ready.
+    
+    This fixes the issue where the machine is ready, but Ground Control doesn't know the machine is ready and the system locks up.
+    */
+    static unsigned long lastRan = millis();
+    int                  timeout = 1000;
+    
+    if (millis() - lastRan > timeout){
+        Serial.println("gready");
+        Serial.println("watchdog ran");
+        
+        lastRan = millis();
+    }
+}
+
 void readSerialCommands(){
     /*
     Check to see if a new character is available from the serial connection, read it if one is.

--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -128,7 +128,6 @@ void  _watchDog(){
     
     if (millis() - lastRan > timeout){
         Serial.println("gready");
-        Serial.println("watchdog ran");
         
         lastRan = millis();
     }

--- a/cnc_ctrl_v1/cnc_ctrl_v1.ino
+++ b/cnc_ctrl_v1/cnc_ctrl_v1.ino
@@ -51,4 +51,6 @@ void loop(){
     readSerialCommands();
     
     returnPoz(xTarget, yTarget, zAxis.read());
+    
+    _watchDog();
 }


### PR DESCRIPTION
Add a watchdog which tells Ground Control that maslow is ready to recieve commands every second when the machine is ready. This catchs the case where a command is dropped between Maslow and Ground Control where Maslow is ready, but Ground Control doesn't know and the system locks up.