### PR TITLE
Create manual overide for chain lengths

### DIFF
--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -724,6 +724,21 @@ void  interpretCommandString(String readString){
         Serial.println("ready");
     }
     
+    if(readString.substring(0, 3) == "B06"){
+        Serial.println("Manually Setting Chain Lengths To: ");
+        float newL = extractGcodeValue(readString, 'L', 0);
+        float newR = extractGcodeValue(readString, 'R', 0);
+        Serial.print("Left: ");
+        Serial.print(newL);
+        Serial.println("mm");
+        Serial.print("Right: ");
+        Serial.print(newR);
+        Serial.println("mm");
+        
+        leftAxis.set(newL);
+        rightAxis.set(newR);
+    }
+    
     if((readString[0] == 'T' || readString[0] == 't') && readString[1] != 'e'){
         Serial.print("Please insert tool ");
         Serial.println(readString);


### PR DESCRIPTION
One backer has a very different design which mounts the motors in such a way that the automaic chain length measuring system can't be used accurately. The B06 command allows for manual override to set the lengths of the chains to some known length