### PR TITLE
Set z-axis depth to a realistc value

### DIFF
--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -61,7 +61,7 @@ bool zAxisAttached = false;
 #define ENC 5
 
 float distPerRot = 10*6.35;//#teeth*pitch of chain
-float zDistPerRot = 635;//1/8inch in mm
+float zDistPerRot = 3.17;//1/8inch in mm
 float encoderSteps = 8148.0;
 float zEncoderSteps = 8148.0;
 
@@ -371,7 +371,7 @@ int   G1(String readString){
     //if the zaxis is attached
     if(zAxisAttached){
         if (zgoto != currentZPos/_inchesToMMConversion){
-            singleAxisMove(&zAxis, zgoto,40);
+            singleAxisMove(&zAxis, zgoto,45);
         }
     }
     else{


### PR DESCRIPTION
PR #143 broke the z-axis, but thorugh no falut of it's own. The z-axis depth was being set using a magic number which was some cobination of the encoder resolution and gear ratio. Now it's using a real number, but needs to be checked against the motor data sheet