### PR TITLE
Constrain the maximum feedrate

### DIFF
--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -366,8 +366,12 @@ int   G1(String readString){
     ygoto      = _inchesToMMConversion*extractGcodeValue(readString, 'Y', currentYPos/_inchesToMMConversion);
     zgoto      = _inchesToMMConversion*extractGcodeValue(readString, 'Z', currentZPos/_inchesToMMConversion);
     feedrate   = _inchesToMMConversion*extractGcodeValue(readString, 'F', feedrate/_inchesToMMConversion);
-    feedrate   = constrain(feedrate, 1, 25*_inchesToMMConversion);                                              //constrain the maximum feedrate
     isNotRapid = extractGcodeValue(readString, 'G', 1);
+    
+    feedrate   = constrain(feedrate, 1, 25*_inchesToMMConversion);                                              //constrain the maximum feedrate
+    if (feedrate == 25*_inchesToMMConversion){
+        Serial.println("Feedrate limited to preserve accuracy");
+    }
     
     //if the zaxis is attached
     if(zAxisAttached){

--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -366,6 +366,7 @@ int   G1(String readString){
     ygoto      = _inchesToMMConversion*extractGcodeValue(readString, 'Y', currentYPos/_inchesToMMConversion);
     zgoto      = _inchesToMMConversion*extractGcodeValue(readString, 'Z', currentZPos/_inchesToMMConversion);
     feedrate   = _inchesToMMConversion*extractGcodeValue(readString, 'F', feedrate/_inchesToMMConversion);
+    feedrate   = constrain(feedrate, 1, 25*_inchesToMMConversion);                                              //constrain the maximum feedrate
     isNotRapid = extractGcodeValue(readString, 'G', 1);
     
     //if the zaxis is attached


### PR DESCRIPTION
Add a firmware limit so that if the machine is commanded to move faster than it is possible for it to move it won't produce inacurate cuts.