### PR TITLE
Add support for universal gcode sender

### DIFF
--- a/cnc_ctrl_v1/Axis.cpp
+++ b/cnc_ctrl_v1/Axis.cpp
@@ -157,6 +157,16 @@ int    Axis::attach(){
      return 1;
 }
 
+bool   Axis::attached(){
+    /*
+    
+    Returns true if the axis is attached, false if it is not.
+    
+    */
+    
+    return _motor.attached();
+}
+
 void   Axis::hold(){
     int timeout   = 2000;
     

--- a/cnc_ctrl_v1/Axis.h
+++ b/cnc_ctrl_v1/Axis.h
@@ -47,6 +47,7 @@
             void   test();
             void   changePitch(float newPitch);
             void   changeEncoderResolution(int newResolution);
+            bool   attached();
             
         private:
             int        _PWMread(int pin);

--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -108,7 +108,6 @@ void  returnPoz(float x, float y, float z){
         Serial.println("]");
         */
         
-        Serial.println("The buffer is:");
         ringBuffer.print();
         lastRan = millis();
     }

--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -564,7 +564,6 @@ void  G10(String readString){
     zAxis.set(zgoto);
     zAxis.endMove(zgoto);
     zAxis.attach();
-    leftAxis.detach();
 }
 
 void  calibrateChainLengths(){
@@ -659,11 +658,14 @@ void  updateSettings(String readString){
 void  executeGcodeLine(String gcodeLine){
     /*
     
-    Executes a single line of gcode
+    Executes a single line of gcode beginning with the character 'G' or 'B'. If neither code is
+    included on the front of the line, the code from the prevous line will be added.
     
     */
     
-    //Serial.println(gcodeLine);
+    int gNumber = extractGcodeValue(gcodeLine,'G', -1);
+    Serial.print("G-number: ");
+    Serial.println(gNumber);
     
     if(gcodeLine.substring(0, 3) == "G00" || gcodeLine.substring(0, 3) == "G01" || gcodeLine.substring(0, 3) == "G02" || gcodeLine.substring(0, 3) == "G03" || gcodeLine.substring(0, 2) == "G0" || gcodeLine.substring(0, 2) == "G1" || gcodeLine.substring(0, 2) == "G2" || gcodeLine.substring(0, 2) == "G3"){
         prependString = gcodeLine.substring(0, 3);
@@ -674,49 +676,34 @@ void  executeGcodeLine(String gcodeLine){
         gcodeLine = prependString + gcodeLine;
     }
     
-    if(gcodeLine.substring(0, 3) == "G01" || gcodeLine.substring(0, 3) == "G00" || gcodeLine.substring(0, 3) == "G0 " || gcodeLine.substring(0, 3) == "G1 "){
-        
-        G1(gcodeLine);
-        gcodeLine = "";
-    }
-    
-    if(gcodeLine.substring(0, 3) == "G02" || gcodeLine.substring(0, 3) == "G2 "){
-        G2(gcodeLine);
-        gcodeLine = "";
-    }
-    
-    if(gcodeLine.substring(0, 3) == "G03" || gcodeLine.substring(0, 3) == "G3 "){
-        G2(gcodeLine);
-        gcodeLine = "";
-    }
-    
-    if(gcodeLine.substring(0, 3) == "G10"){
-        G10(gcodeLine);
-        gcodeLine = "";
-    }
-    
-    if(gcodeLine.substring(0, 3) == "G17"){ //XY plane is the default so no action is taken
-        gcodeLine = "";
-    }
-    
-    if(gcodeLine.substring(0, 3) == "G20"){
-        setInchesToMillimetersConversion(INCHES);
-        gcodeLine = "";
-    }
-    
-    if(gcodeLine.substring(0, 3) == "G21"){
-        setInchesToMillimetersConversion(MILLIMETERS);
-        gcodeLine = "";
-    }
-    
-    if(gcodeLine.substring(0, 3) == "G90"){ //Switch to absolute units
-        useRelativeUnits = false;
-        gcodeLine = "";
-    }
-    
-    if(gcodeLine.substring(0, 3) == "G91"){ //Switch to relative units
-        useRelativeUnits = true;
-        gcodeLine = "";
+    switch(gNumber){
+        case 0:
+            G1(gcodeLine);
+            break;
+        case 1:
+            G1(gcodeLine);
+            break;
+        case 2:
+            G2(gcodeLine);
+            break;
+        case 3:
+            G2(gcodeLine);
+            break;
+        case 10:
+            G10(gcodeLine);
+            break;
+        case 20:
+            setInchesToMillimetersConversion(INCHES);
+            break;
+        case 21:
+            setInchesToMillimetersConversion(MILLIMETERS);
+            break;
+        case 90:
+            useRelativeUnits = false;
+            break;
+        case 91:
+            useRelativeUnits = true;
+            break;
     }
     
     if(gcodeLine.substring(0, 3) == "M06"){ //Tool change are default so no action is taken

--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -635,6 +635,8 @@ void executeGcodeLine(String gcodeLine){
     
     Serial.println(gcodeLine);
     
+    Serial.println("then this ran");
+    
     if(readString.substring(0, 3) == "G00" || readString.substring(0, 3) == "G01" || readString.substring(0, 3) == "G02" || readString.substring(0, 3) == "G03" || readString.substring(0, 2) == "G0" || readString.substring(0, 2) == "G1" || readString.substring(0, 2) == "G2" || readString.substring(0, 2) == "G3"){
         prependString = readString.substring(0, 3);
         prependString = prependString + " ";
@@ -794,17 +796,25 @@ void  interpretCommandString(String readString){
     int firstG;
     int secondG;
     
-    while (firstG >= 0){
-        //extract one command from the line
-        firstG  = readString.indexOf('G', firstG);
-        secondG = readString.indexOf('G', firstG + 1);
-    
-        String gcodeLine = readString.substring(firstG, secondG);
-    
-        //execute the line
-        executeGcodeLine(gcodeLine);
+    if (readString.indexOf('G') != -1){
+        //if the line contains a 'G'
+        while (firstG >= 0){
+            //extract one command from the line
+            firstG  = readString.indexOf('G', firstG);
+            secondG = readString.indexOf('G', firstG + 1);
         
-        firstG = secondG;
+            String gcodeLine = readString.substring(firstG, secondG);
+        
+            //execute the line
+            executeGcodeLine(gcodeLine);
+            
+            firstG = secondG;
+        }
+    }
+    else{
+        //try to execute the line anyway, it might be a B code or something else
+        Serial.println("this ran");
+        executeGcodeLine(readString);
     }
     
 }

--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -626,16 +626,14 @@ void  updateSettings(String readString){
     Serial.println("Machine Settings Updated");
 }
 
-void  interpretCommandString(String readString){
-    int i = 0;
-    char sect[22];
+void executeGcodeLine(String gcodeLine){
+    /*
     
-    while (i < 23){
-        sect[i] = ' ';
-        i++;
-    }
+    Executes a single line of gcode
     
-    Serial.println(readString);
+    */
+    
+    Serial.println(gcodeLine);
     
     if(readString.substring(0, 3) == "G00" || readString.substring(0, 3) == "G01" || readString.substring(0, 3) == "G02" || readString.substring(0, 3) == "G03" || readString.substring(0, 2) == "G0" || readString.substring(0, 2) == "G1" || readString.substring(0, 2) == "G2" || readString.substring(0, 2) == "G3"){
         prependString = readString.substring(0, 3);
@@ -783,3 +781,30 @@ void  interpretCommandString(String readString){
         Serial.println("ready");
     }
 } 
+
+void  interpretCommandString(String readString){
+    /*
+    
+    Splits a string into lines of gcode which begin with 'G'
+    
+    */
+    Serial.println("debug: ");
+    Serial.println(readString);
+    
+    int firstG;
+    int secondG;
+    
+    while (firstG >= 0){
+        //extract one command from the line
+        firstG  = readString.indexOf('G', firstG);
+        secondG = readString.indexOf('G', firstG + 1);
+    
+        String gcodeLine = readString.substring(firstG, secondG);
+    
+        //execute the line
+        executeGcodeLine(gcodeLine);
+        
+        firstG = secondG;
+    }
+    
+}

--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -600,7 +600,7 @@ void  updateSettings(String readString){
     float motorOffsetX       = extractGcodeValue(readString, 'D', (distBetweenMotors - bedWidth)/2); //read the motor offset X IF it is sent, if it's not sent, compute it from the spacing between the motors
     float motorOffsetY       = extractGcodeValue(readString, 'E', motorOffsetY);
     float sledWidth          = extractGcodeValue(readString, 'F', kinematics.l);
-    float sledHeight         = extractGcodeValue(readString, 'G', kinematics.s);
+    float sledHeight         = extractGcodeValue(readString, 'R', kinematics.s);
     float sledCG             = extractGcodeValue(readString, 'H', kinematics.h3);
     zAxisAttached            = extractGcodeValue(readString, 'I', zAxisAttached);
     int encoderSteps         = extractGcodeValue(readString, 'J', ENCODERSTEPS);
@@ -690,10 +690,7 @@ void  executeGcodeLine(String gcodeLine){
             break;
     }
     
-    if(gcodeLine.substring(0, 3) == "M06"){ //Tool change are default so no action is taken
-        gcodeLine = "";
-    }
-    
+
     if(gcodeLine.substring(0, 3) == "B01"){
         
         leftAxis.computeMotorResponse();
@@ -782,19 +779,23 @@ void  interpretCommandString(String cmdString){
     int firstG;  
     int secondG;
     
-    while(cmdString.length() > 0){
-        firstG  = findNextG(cmdString, 0);
-        secondG = findNextG(cmdString, firstG + 1);
-        
-        String gcodeLine = cmdString.substring(firstG, secondG);
-        
-        Serial.println(gcodeLine);
-        executeGcodeLine(gcodeLine);
-        
-        cmdString = cmdString.substring(secondG, cmdString.length());
-        
+    if (cmdString[0] == 'B'){                   //If the command is a B command
+        executeGcodeLine(cmdString);
     }
-    
+    else{
+        while(cmdString.length() > 0){          //Extract each line of gcode from the string
+            firstG  = findNextG(cmdString, 0);
+            secondG = findNextG(cmdString, firstG + 1);
+            
+            String gcodeLine = cmdString.substring(firstG, secondG);
+            
+            Serial.println(gcodeLine);
+            executeGcodeLine(gcodeLine);
+            
+            cmdString = cmdString.substring(secondG, cmdString.length());
+            
+        }
+    }
     
     Serial.println("ok");
     

--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -95,22 +95,25 @@ void  returnPoz(float x, float y, float z){
     if (millis() - lastRan > timeout){
         float errorTerm = (leftAxis.error() + rightAxis.error() )/2;
         
-        Serial.print("pz(");
-        Serial.print(x/_inchesToMMConversion);
-        Serial.print(", ");
-        Serial.print(y/_inchesToMMConversion);
-        Serial.print(", ");
-        Serial.print(z/_inchesToMMConversion);
-        Serial.print(", ");
-        Serial.print(errorTerm);
-        Serial.print(")");
         
-        if (_inchesToMMConversion == INCHES){
+        //Serial.println("<Idle,MPos:1.000,2.000,0.000,WPos:0.000,0.000,0.000>");
+        Serial.print("<Idle,MPos:");
+        Serial.print(x/_inchesToMMConversion);
+        Serial.print(",");
+        Serial.print(y/_inchesToMMConversion);
+        Serial.print(",");
+        Serial.print(z/_inchesToMMConversion);
+        //Serial.print(",");
+        //Serial.print(errorTerm);
+        Serial.println(",WPos:0.000,0.000,0.000>");
+        
+        
+        /*if (_inchesToMMConversion == INCHES){
             Serial.println("in");
         }
         else{
             Serial.println("mm");
-        }
+        }*/
         
         lastRan = millis();
     }
@@ -128,7 +131,7 @@ void  _watchDog(){
     int                  timeout = 1000;
     
     if (millis() - lastRan > timeout){
-        //Serial.println("gready");
+        //Serial.println("ok");
         
         lastRan = millis();
     }
@@ -646,7 +649,7 @@ void  interpretCommandString(String readString){
     if(readString.substring(0, 3) == "G01" || readString.substring(0, 3) == "G00" || readString.substring(0, 3) == "G0 " || readString.substring(0, 3) == "G1 "){
         
         G1(readString);
-        Serial.println("gready");
+        Serial.println("ok");
         Serial.println("ready");
         readString = "";
     }
@@ -654,52 +657,52 @@ void  interpretCommandString(String readString){
     if(readString.substring(0, 3) == "G02" || readString.substring(0, 3) == "G2 "){
         G2(readString);
         Serial.println("ready");
-        Serial.println("gready");
+        Serial.println("ok");
         readString = "";
     }
     
     if(readString.substring(0, 3) == "G03" || readString.substring(0, 3) == "G3 "){
         G2(readString);
-        Serial.println("gready");
+        Serial.println("ok");
         Serial.println("ready");
         readString = "";
     }
     
     if(readString.substring(0, 3) == "G10"){
         G10(readString);
-        Serial.println("gready");
+        Serial.println("ok");
         Serial.println("ready");
         readString = "";
     }
     
     if(readString.substring(0, 3) == "G17"){ //XY plane is the default so no action is taken
-        Serial.println("gready");
+        Serial.println("ok");
         Serial.println("ready");
         readString = "";
     }
     
     if(readString.substring(0, 3) == "G20"){
         setInchesToMillimetersConversion(INCHES);
-        Serial.println("gready");
+        Serial.println("ok");
         Serial.println("ready");
         readString = "";
     }
     
     if(readString.substring(0, 3) == "G21"){
         setInchesToMillimetersConversion(MILLIMETERS);
-        Serial.println("gready");
+        Serial.println("ok");
         Serial.println("ready");
         readString = "";
     }
     
     if(readString.substring(0, 3) == "G90"){ //G90 is the default so no action is taken
-        Serial.println("gready");
+        Serial.println("ok");
         Serial.println("ready");
         readString = "";
     }
     
     if(readString.substring(0, 3) == "M06"){ //Tool change are default so no action is taken
-        Serial.println("gready");
+        Serial.println("ok");
         Serial.println("ready");
         readString = "";
     }
@@ -710,21 +713,21 @@ void  interpretCommandString(String readString){
         rightAxis.computeMotorResponse();
         
         readString = "";
-        Serial.println("gready");
+        Serial.println("ok");
         Serial.println("ready");
     }
     
     if(readString.substring(0, 3) == "B02"){
         calibrateChainLengths();
         readString = "";
-        Serial.println("gready");
+        Serial.println("ok");
         Serial.println("ready");
     }
     
     if(readString.substring(0, 3) == "B03"){
         updateSettings(readString);
         readString = "";
-        Serial.println("gready");
+        Serial.println("ok");
         Serial.println("ready");
     }
     
@@ -738,7 +741,7 @@ void  interpretCommandString(String readString){
         zAxis.test();
         Serial.println("Tests complete.");
         readString = "";
-        Serial.println("gready");
+        Serial.println("ok");
         Serial.println("ready");
     }
     
@@ -746,7 +749,7 @@ void  interpretCommandString(String readString){
         Serial.print("Firmware Version ");
         Serial.println(VERSIONNUMBER);
         readString = "";
-        Serial.println("gready");
+        Serial.println("ok");
         Serial.println("ready");
     }
     
@@ -768,7 +771,7 @@ void  interpretCommandString(String readString){
     if((readString[0] == 'T' || readString[0] == 't') && readString[1] != 'e'){
         Serial.print("Please insert tool ");
         Serial.println(readString);
-        Serial.println("gready");
+        Serial.println("ok");
         Serial.println("ready");
         readString = "";
     }
@@ -776,7 +779,7 @@ void  interpretCommandString(String readString){
     if (readString.length() > 0){
         Serial.println(readString);
         readString = "";
-        Serial.println("gready");
+        Serial.println("ok");
         Serial.println("ready");
     }
 } 

--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -96,7 +96,7 @@ void  returnPoz(float x, float y, float z){
         float errorTerm = (leftAxis.error() + rightAxis.error() )/2;
         
         
-        //Serial.println("<Idle,MPos:1.000,2.000,0.000,WPos:0.000,0.000,0.000>");
+        /*//Serial.println("<Idle,MPos:1.000,2.000,0.000,WPos:0.000,0.000,0.000>");
         Serial.print("<Idle,MPos:");
         Serial.print(x/_inchesToMMConversion);
         Serial.print(",");
@@ -105,7 +105,7 @@ void  returnPoz(float x, float y, float z){
         Serial.print(z/_inchesToMMConversion);
         //Serial.print(",");
         //Serial.print(errorTerm);
-        Serial.println(",WPos:0.000,0.000,0.000>");
+        Serial.println(",WPos:0.000,0.000,0.000>");*/
         
         
         /*if (_inchesToMMConversion == INCHES){
@@ -626,14 +626,14 @@ void  updateSettings(String readString){
     Serial.println("Machine Settings Updated");
 }
 
-void executeGcodeLine(String gcodeLine){
+void  executeGcodeLine(String gcodeLine){
     /*
     
     Executes a single line of gcode
     
     */
     
-    Serial.println(gcodeLine);
+    //Serial.println(gcodeLine);
     
     if(gcodeLine.substring(0, 3) == "G00" || gcodeLine.substring(0, 3) == "G01" || gcodeLine.substring(0, 3) == "G02" || gcodeLine.substring(0, 3) == "G03" || gcodeLine.substring(0, 2) == "G0" || gcodeLine.substring(0, 2) == "G1" || gcodeLine.substring(0, 2) == "G2" || gcodeLine.substring(0, 2) == "G3"){
         prependString = gcodeLine.substring(0, 3);
@@ -647,61 +647,43 @@ void executeGcodeLine(String gcodeLine){
     if(gcodeLine.substring(0, 3) == "G01" || gcodeLine.substring(0, 3) == "G00" || gcodeLine.substring(0, 3) == "G0 " || gcodeLine.substring(0, 3) == "G1 "){
         
         G1(gcodeLine);
-        Serial.println("ok");
-        Serial.println("ready");
         gcodeLine = "";
     }
     
     if(gcodeLine.substring(0, 3) == "G02" || gcodeLine.substring(0, 3) == "G2 "){
         G2(gcodeLine);
-        Serial.println("ready");
-        Serial.println("ok");
         gcodeLine = "";
     }
     
     if(gcodeLine.substring(0, 3) == "G03" || gcodeLine.substring(0, 3) == "G3 "){
         G2(gcodeLine);
-        Serial.println("ok");
-        Serial.println("ready");
         gcodeLine = "";
     }
     
     if(gcodeLine.substring(0, 3) == "G10"){
         G10(gcodeLine);
-        Serial.println("ok");
-        Serial.println("ready");
         gcodeLine = "";
     }
     
     if(gcodeLine.substring(0, 3) == "G17"){ //XY plane is the default so no action is taken
-        Serial.println("ok");
-        Serial.println("ready");
         gcodeLine = "";
     }
     
     if(gcodeLine.substring(0, 3) == "G20"){
         setInchesToMillimetersConversion(INCHES);
-        Serial.println("ok");
-        Serial.println("ready");
         gcodeLine = "";
     }
     
     if(gcodeLine.substring(0, 3) == "G21"){
         setInchesToMillimetersConversion(MILLIMETERS);
-        Serial.println("ok");
-        Serial.println("ready");
         gcodeLine = "";
     }
     
     if(gcodeLine.substring(0, 3) == "G90"){ //G90 is the default so no action is taken
-        Serial.println("ok");
-        Serial.println("ready");
         gcodeLine = "";
     }
     
     if(gcodeLine.substring(0, 3) == "M06"){ //Tool change are default so no action is taken
-        Serial.println("ok");
-        Serial.println("ready");
         gcodeLine = "";
     }
     
@@ -769,52 +751,51 @@ void executeGcodeLine(String gcodeLine){
     if((gcodeLine[0] == 'T' || gcodeLine[0] == 't') && gcodeLine[1] != 'e'){
         Serial.print("Please insert tool ");
         Serial.println(gcodeLine);
-        Serial.println("ok");
-        Serial.println("ready");
         gcodeLine = "";
     }
     
-    if (gcodeLine.length() > 0){
-        Serial.println(gcodeLine);
-        gcodeLine = "";
-        Serial.println("ok");
-        Serial.println("ready");
-    }
 } 
 
-void  interpretCommandString(String readString){
+int  findNextG(String readString, int startingPoint){
+    int nextGIndex = readString.indexOf('G', startingPoint);
+    if(nextGIndex == -1){
+        nextGIndex = readString.length();
+    }
+    
+    return nextGIndex;
+}
+
+void  interpretCommandString(String cmdString){
     /*
     
     Splits a string into lines of gcode which begin with 'G'
     
     */
     
-    int firstG;
+    cmdString = "?G91 G20 G0 X10";
+    
+    Serial.println("before");
+    
+    Serial.println(cmdString);
+    
+    int firstG;  
     int secondG;
     
-    if (readString.indexOf('G') != -1){
-        //if the line contains a 'G'
-        while (readString.length() > 0){
-            //extract one command from the line
-            firstG  = readString.indexOf('G', firstG);
-            secondG = readString.indexOf('G', firstG + 1);
-            if (secondG == -1){                                 //no second line detected
-                secondG = readString.length();
-            }
-            
-            String gcodeLine = readString.substring(firstG, secondG);
+    while(cmdString.length() > 0){
+        firstG  = findNextG(cmdString, 0);
+        secondG = findNextG(cmdString, firstG + 1);
         
-            //execute the line
-            executeGcodeLine(gcodeLine);
-            
-            readString = readString.substring(secondG, readString.length());
-            
-        }
+        String gcodeLine = cmdString.substring(firstG, secondG);
+        
+        Serial.println(gcodeLine);
+        
+        cmdString = cmdString.substring(secondG, cmdString.length());
+        
+        Serial.println(cmdString);
     }
-    else{
-        //try to execute the line anyway, it might be a B code or something else
-        Serial.println("Line does not seem to contain a G");
-        executeGcodeLine(readString);
-    }
+    
+    Serial.println("after");
+    
+    Serial.println("ok");
     
 }

--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -772,7 +772,7 @@ void  interpretCommandString(String cmdString){
     
     */
     
-    cmdString = "?G91 G20 G0 X10";
+    //cmdString = "?G91 G20 G0 X10";
     
     Serial.println("before");
     
@@ -788,6 +788,7 @@ void  interpretCommandString(String cmdString){
         String gcodeLine = cmdString.substring(firstG, secondG);
         
         Serial.println(gcodeLine);
+        executeGcodeLine(gcodeLine);
         
         cmdString = cmdString.substring(secondG, cmdString.length());
         

--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -94,7 +94,6 @@ void  returnPoz(float x, float y, float z){
         float errorTerm = (leftAxis.error() + rightAxis.error() )/2;
         
         
-        //Serial.println("<Idle,MPos:1.000,2.000,0.000,WPos:0.000,0.000,0.000>");
         Serial.print("<Idle,MPos:");
         Serial.print(x/_inchesToMMConversion);
         Serial.print(",");
@@ -103,9 +102,9 @@ void  returnPoz(float x, float y, float z){
         Serial.print(z/_inchesToMMConversion);
         Serial.println(",WPos:0.000,0.000,0.000>");
         
-        //Serial.print("[PosError:");
-        //Serial.print(errorTerm);
-        //Serial.println("]");
+        Serial.print("[PosError:");
+        Serial.print(errorTerm);
+        Serial.println("]");
         
         //ringBuffer.print();
         lastRan = millis();
@@ -343,9 +342,6 @@ If no number is found, defaultReturn is returned*/
     end             =  findEndOfNumber(readString,begin+1);
     numberAsString  =  readString.substring(begin+1,end);
     
-    //Serial.print("Number as a string: ");
-    //Serial.println(numberAsString);
-    
     numberAsFloat   =  numberAsString.toFloat();
     
     if (begin == -1){ //if the character was not found, return error
@@ -422,7 +418,6 @@ int   G1(String readString){
                 holdPosition();
             } 
         }
-        //Serial.println("ok");
     }
     
     

--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -106,10 +106,20 @@ void  returnPoz(float x, float y, float z){
         Serial.print(errorTerm);
         Serial.println("]");
         
-        //ringBuffer.print();
         lastRan = millis();
     }
     
+}
+
+void  _signalReady(){
+    /*
+    
+    Signal to the controlling software that the machine has executed the last
+    gcode line successfully.
+    
+    */
+    
+    Serial.println("ok");
 }
 
 void  _watchDog(){
@@ -120,10 +130,10 @@ void  _watchDog(){
     This fixes the issue where the machine is ready, but Ground Control doesn't know the machine is ready and the system locks up.
     */
     static unsigned long lastRan = millis();
-    int                  timeout = 1000;
+    int                  timeout = 3000;
     
     if (millis() - lastRan > timeout){
-        //Serial.println("ok");
+        //_signalReady();
         
         lastRan = millis();
     }
@@ -133,10 +143,8 @@ void readSerialCommands(){
     /*
     Check to see if a new character is available from the serial connection, read it if one is.
     */
-    if (Serial.available() > 0) {
-        
+    while (Serial.available() > 0) {
         ringBuffer.write(Serial.read()); //gets one byte from serial buffer, writes it to the internal ring buffer
-        
     }
 }
 
@@ -697,21 +705,21 @@ void  executeGcodeLine(String gcodeLine){
         rightAxis.computeMotorResponse();
         
         gcodeLine = "";
-        Serial.println("ok");
+        _signalReady();
         Serial.println("ready");
     }
     
     if(gcodeLine.substring(0, 3) == "B02"){
         calibrateChainLengths();
         gcodeLine = "";
-        Serial.println("ok");
+        _signalReady();
         Serial.println("ready");
     }
     
     if(gcodeLine.substring(0, 3) == "B03"){
         updateSettings(gcodeLine);
         gcodeLine = "";
-        Serial.println("ok");
+        _signalReady();
         Serial.println("ready");
     }
     
@@ -725,7 +733,7 @@ void  executeGcodeLine(String gcodeLine){
         zAxis.test();
         Serial.println("Tests complete.");
         gcodeLine = "";
-        Serial.println("ok");
+        _signalReady();
         Serial.println("ready");
     }
     
@@ -733,7 +741,7 @@ void  executeGcodeLine(String gcodeLine){
         Serial.print("Firmware Version ");
         Serial.println(VERSIONNUMBER);
         gcodeLine = "";
-        Serial.println("ok");
+        _signalReady();
         Serial.println("ready");
     }
     
@@ -797,6 +805,6 @@ void  interpretCommandString(String cmdString){
         }
     }
     
-    Serial.println("ok");
+    _signalReady();
     
 }

--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -88,12 +88,12 @@ void  returnPoz(float x, float y, float z){
     */
     
     static unsigned long lastRan = millis();
-    int                  timeout = 9000;
+    int                  timeout = 200;
     
     if (millis() - lastRan > timeout){
         float errorTerm = (leftAxis.error() + rightAxis.error() )/2;
         
-        /*
+        
         //Serial.println("<Idle,MPos:1.000,2.000,0.000,WPos:0.000,0.000,0.000>");
         Serial.print("<Idle,MPos:");
         Serial.print(x/_inchesToMMConversion);
@@ -103,12 +103,11 @@ void  returnPoz(float x, float y, float z){
         Serial.print(z/_inchesToMMConversion);
         Serial.println(",WPos:0.000,0.000,0.000>");
         
-        Serial.print("[PosError:");
-        Serial.print(errorTerm);
-        Serial.println("]");
-        */
+        //Serial.print("[PosError:");
+        //Serial.print(errorTerm);
+        //Serial.println("]");
         
-        ringBuffer.print();
+        //ringBuffer.print();
         lastRan = millis();
     }
     
@@ -136,16 +135,9 @@ void readSerialCommands(){
     Check to see if a new character is available from the serial connection, read it if one is.
     */
     if (Serial.available() > 0) {
-        char c = Serial.read();  //gets one byte from serial buffer
-        ringBuffer.write(c);
         
-        /*if (c == '\n'){
-            readyCommandString = readString;
-            readString = "";
-        }
-        else{
-            readString += c; //makes the string readString
-        }*/
+        ringBuffer.write(Serial.read()); //gets one byte from serial buffer, writes it to the internal ring buffer
+        
     }
 }
 
@@ -398,20 +390,14 @@ int   G1(String readString){
     }
     
     feedrate   = constrain(feedrate, 1, 25*_inchesToMMConversion);                                              //constrain the maximum feedrate
-    if (feedrate == 25*_inchesToMMConversion){
-        Serial.println("Feedrate limited to preserve accuracy");
-    }
     
     //if the zaxis is attached
     if(zAxisAttached){
-        Serial.println("before z move");
         if (zgoto != currentZPos/_inchesToMMConversion){
             singleAxisMove(&zAxis, zgoto,45);
         }
-        Serial.println("after zmove");
     }
     else{
-        Serial.println("manual z move");
         float threshold = .1; //units of mm
         if (abs(currentZPos - zgoto) > threshold){
             Serial.print("Message: Please adjust Z-Axis to a depth of ");

--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -88,7 +88,7 @@ void  returnPoz(float x, float y, float z){
     */
     
     static unsigned long lastRan = millis();
-    int                  timeout = 2000;
+    int                  timeout = 9000;
     
     if (millis() - lastRan > timeout){
         float errorTerm = (leftAxis.error() + rightAxis.error() )/2;

--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -104,17 +104,11 @@ void  returnPoz(float x, float y, float z){
         Serial.print(y/_inchesToMMConversion);
         Serial.print(",");
         Serial.print(z/_inchesToMMConversion);
-        //Serial.print(",");
-        //Serial.print(errorTerm);
         Serial.println(",WPos:0.000,0.000,0.000>");
         
-        
-        /*if (_inchesToMMConversion == INCHES){
-            Serial.println("in");
-        }
-        else{
-            Serial.println("mm");
-        }*/
+        Serial.print("[PosError:");
+        Serial.print(errorTerm);
+        Serial.println("]");
         
         lastRan = millis();
     }

--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -635,103 +635,101 @@ void executeGcodeLine(String gcodeLine){
     
     Serial.println(gcodeLine);
     
-    Serial.println("then this ran");
-    
-    if(readString.substring(0, 3) == "G00" || readString.substring(0, 3) == "G01" || readString.substring(0, 3) == "G02" || readString.substring(0, 3) == "G03" || readString.substring(0, 2) == "G0" || readString.substring(0, 2) == "G1" || readString.substring(0, 2) == "G2" || readString.substring(0, 2) == "G3"){
-        prependString = readString.substring(0, 3);
+    if(gcodeLine.substring(0, 3) == "G00" || gcodeLine.substring(0, 3) == "G01" || gcodeLine.substring(0, 3) == "G02" || gcodeLine.substring(0, 3) == "G03" || gcodeLine.substring(0, 2) == "G0" || gcodeLine.substring(0, 2) == "G1" || gcodeLine.substring(0, 2) == "G2" || gcodeLine.substring(0, 2) == "G3"){
+        prependString = gcodeLine.substring(0, 3);
         prependString = prependString + " ";
     }
     
-    if(readString[0] == 'X' || readString[0] == 'Y' || readString[0] == 'Z'){
-        readString = prependString + readString;
+    if(gcodeLine[0] == 'X' || gcodeLine[0] == 'Y' || gcodeLine[0] == 'Z'){
+        gcodeLine = prependString + gcodeLine;
     }
     
-    if(readString.substring(0, 3) == "G01" || readString.substring(0, 3) == "G00" || readString.substring(0, 3) == "G0 " || readString.substring(0, 3) == "G1 "){
+    if(gcodeLine.substring(0, 3) == "G01" || gcodeLine.substring(0, 3) == "G00" || gcodeLine.substring(0, 3) == "G0 " || gcodeLine.substring(0, 3) == "G1 "){
         
-        G1(readString);
+        G1(gcodeLine);
         Serial.println("ok");
         Serial.println("ready");
-        readString = "";
+        gcodeLine = "";
     }
     
-    if(readString.substring(0, 3) == "G02" || readString.substring(0, 3) == "G2 "){
-        G2(readString);
+    if(gcodeLine.substring(0, 3) == "G02" || gcodeLine.substring(0, 3) == "G2 "){
+        G2(gcodeLine);
         Serial.println("ready");
         Serial.println("ok");
-        readString = "";
+        gcodeLine = "";
     }
     
-    if(readString.substring(0, 3) == "G03" || readString.substring(0, 3) == "G3 "){
-        G2(readString);
+    if(gcodeLine.substring(0, 3) == "G03" || gcodeLine.substring(0, 3) == "G3 "){
+        G2(gcodeLine);
         Serial.println("ok");
         Serial.println("ready");
-        readString = "";
+        gcodeLine = "";
     }
     
-    if(readString.substring(0, 3) == "G10"){
-        G10(readString);
+    if(gcodeLine.substring(0, 3) == "G10"){
+        G10(gcodeLine);
         Serial.println("ok");
         Serial.println("ready");
-        readString = "";
+        gcodeLine = "";
     }
     
-    if(readString.substring(0, 3) == "G17"){ //XY plane is the default so no action is taken
+    if(gcodeLine.substring(0, 3) == "G17"){ //XY plane is the default so no action is taken
         Serial.println("ok");
         Serial.println("ready");
-        readString = "";
+        gcodeLine = "";
     }
     
-    if(readString.substring(0, 3) == "G20"){
+    if(gcodeLine.substring(0, 3) == "G20"){
         setInchesToMillimetersConversion(INCHES);
         Serial.println("ok");
         Serial.println("ready");
-        readString = "";
+        gcodeLine = "";
     }
     
-    if(readString.substring(0, 3) == "G21"){
+    if(gcodeLine.substring(0, 3) == "G21"){
         setInchesToMillimetersConversion(MILLIMETERS);
         Serial.println("ok");
         Serial.println("ready");
-        readString = "";
+        gcodeLine = "";
     }
     
-    if(readString.substring(0, 3) == "G90"){ //G90 is the default so no action is taken
+    if(gcodeLine.substring(0, 3) == "G90"){ //G90 is the default so no action is taken
         Serial.println("ok");
         Serial.println("ready");
-        readString = "";
+        gcodeLine = "";
     }
     
-    if(readString.substring(0, 3) == "M06"){ //Tool change are default so no action is taken
+    if(gcodeLine.substring(0, 3) == "M06"){ //Tool change are default so no action is taken
         Serial.println("ok");
         Serial.println("ready");
-        readString = "";
+        gcodeLine = "";
     }
     
-    if(readString.substring(0, 3) == "B01"){
+    if(gcodeLine.substring(0, 3) == "B01"){
         
         leftAxis.computeMotorResponse();
         rightAxis.computeMotorResponse();
         
-        readString = "";
+        gcodeLine = "";
         Serial.println("ok");
         Serial.println("ready");
     }
     
-    if(readString.substring(0, 3) == "B02"){
+    if(gcodeLine.substring(0, 3) == "B02"){
         calibrateChainLengths();
-        readString = "";
+        gcodeLine = "";
         Serial.println("ok");
         Serial.println("ready");
     }
     
-    if(readString.substring(0, 3) == "B03"){
-        updateSettings(readString);
-        readString = "";
+    if(gcodeLine.substring(0, 3) == "B03"){
+        updateSettings(gcodeLine);
+        gcodeLine = "";
         Serial.println("ok");
         Serial.println("ready");
     }
     
-    if(readString.substring(0, 3) == "B04"){
+    if(gcodeLine.substring(0, 3) == "B04"){
         //Test each of the axis
         delay(500);
         leftAxis.test();
@@ -740,23 +738,23 @@ void executeGcodeLine(String gcodeLine){
         delay(500);
         zAxis.test();
         Serial.println("Tests complete.");
-        readString = "";
+        gcodeLine = "";
         Serial.println("ok");
         Serial.println("ready");
     }
     
-    if(readString.substring(0, 3) == "B05"){
+    if(gcodeLine.substring(0, 3) == "B05"){
         Serial.print("Firmware Version ");
         Serial.println(VERSIONNUMBER);
-        readString = "";
+        gcodeLine = "";
         Serial.println("ok");
         Serial.println("ready");
     }
     
-    if(readString.substring(0, 3) == "B06"){
+    if(gcodeLine.substring(0, 3) == "B06"){
         Serial.println("Manually Setting Chain Lengths To: ");
-        float newL = extractGcodeValue(readString, 'L', 0);
-        float newR = extractGcodeValue(readString, 'R', 0);
+        float newL = extractGcodeValue(gcodeLine, 'L', 0);
+        float newR = extractGcodeValue(gcodeLine, 'R', 0);
         Serial.print("Left: ");
         Serial.print(newL);
         Serial.println("mm");
@@ -768,17 +766,17 @@ void executeGcodeLine(String gcodeLine){
         rightAxis.set(newR);
     }
     
-    if((readString[0] == 'T' || readString[0] == 't') && readString[1] != 'e'){
+    if((gcodeLine[0] == 'T' || gcodeLine[0] == 't') && gcodeLine[1] != 'e'){
         Serial.print("Please insert tool ");
-        Serial.println(readString);
+        Serial.println(gcodeLine);
         Serial.println("ok");
         Serial.println("ready");
-        readString = "";
+        gcodeLine = "";
     }
     
-    if (readString.length() > 0){
-        Serial.println(readString);
-        readString = "";
+    if (gcodeLine.length() > 0){
+        Serial.println(gcodeLine);
+        gcodeLine = "";
         Serial.println("ok");
         Serial.println("ready");
     }
@@ -790,30 +788,32 @@ void  interpretCommandString(String readString){
     Splits a string into lines of gcode which begin with 'G'
     
     */
-    Serial.println("debug: ");
-    Serial.println(readString);
     
     int firstG;
     int secondG;
     
     if (readString.indexOf('G') != -1){
         //if the line contains a 'G'
-        while (firstG >= 0){
+        while (readString.length() > 0){
             //extract one command from the line
             firstG  = readString.indexOf('G', firstG);
             secondG = readString.indexOf('G', firstG + 1);
-        
+            if (secondG == -1){                                 //no second line detected
+                secondG = readString.length();
+            }
+            
             String gcodeLine = readString.substring(firstG, secondG);
         
             //execute the line
             executeGcodeLine(gcodeLine);
             
-            firstG = secondG;
+            readString = readString.substring(secondG, readString.length());
+            
         }
     }
     else{
         //try to execute the line anyway, it might be a B code or something else
-        Serial.println("this ran");
+        Serial.println("Line does not seem to contain a G");
         executeGcodeLine(readString);
     }
     

--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -432,6 +432,7 @@ int   G1(String readString){
                 holdPosition();
             } 
         }
+        Serial.println("ok");
     }
     
     
@@ -664,8 +665,6 @@ void  executeGcodeLine(String gcodeLine){
     */
     
     int gNumber = extractGcodeValue(gcodeLine,'G', -1);
-    Serial.print("G-number: ");
-    Serial.println(gNumber);
     
     if(gcodeLine.substring(0, 3) == "G00" || gcodeLine.substring(0, 3) == "G01" || gcodeLine.substring(0, 3) == "G02" || gcodeLine.substring(0, 3) == "G03" || gcodeLine.substring(0, 2) == "G0" || gcodeLine.substring(0, 2) == "G1" || gcodeLine.substring(0, 2) == "G2" || gcodeLine.substring(0, 2) == "G3"){
         prependString = gcodeLine.substring(0, 3);

--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -326,6 +326,22 @@ void  holdPosition(){
     zAxis.hold();
 }
     
+int   findEndOfNumber(String textString, int index){
+    //Return the index of the last digit of the number beginning at the index passed in
+    int i = index;
+    
+    while (i < textString.length()){
+        
+        if(isDigit(textString[i]) or isPunct(textString[i])){ //If we're still looking at a number, keep goin
+            i++;
+        }
+        else{
+            return i;                                         //If we've reached the end of the number, return the last index
+        }
+    }
+    return i;                                                 //If we've reached the end of the string, return the last number
+}
+    
 float extractGcodeValue(String readString, char target,float defaultReturn){
 
 /*Reads a string and returns the value of number following the target character.
@@ -337,8 +353,12 @@ If no number is found, defaultReturn is returned*/
     float numberAsFloat;
     
     begin           =  readString.indexOf(target);
-    end             =  readString.indexOf(' ', begin);
+    end             =  findEndOfNumber(readString,begin+1);
     numberAsString  =  readString.substring(begin+1,end);
+    
+    //Serial.print("Number as a string: ");
+    //Serial.println(numberAsString);
+    
     numberAsFloat   =  numberAsString.toFloat();
     
     if (begin == -1){ //if the character was not found, return error

--- a/cnc_ctrl_v1/Kinematics.h
+++ b/cnc_ctrl_v1/Kinematics.h
@@ -13,7 +13,7 @@
     You should have received a copy of the GNU General Public License
     along with the Maslow Control Software.  If not, see <http://www.gnu.org/licenses/>.
     
-    Copyright 2014-2016 Bar Smith*/
+    Copyright 2014-2017 Bar Smith*/
     
     #ifndef Kinematics_h
     #define Kinematics_h

--- a/cnc_ctrl_v1/RingBuffer.cpp
+++ b/cnc_ctrl_v1/RingBuffer.cpp
@@ -1,0 +1,39 @@
+/*This file is part of the Maslow Control Software.
+
+    The Maslow Control Software is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Maslow Control Software is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with the Maslow Control Software.  If not, see <http://www.gnu.org/licenses/>.
+    
+    Copyright 2014-2017 Bar Smith*/
+
+/*
+The RingBuffer module creates a circular character buffer used for storing incoming
+serial data.
+*/
+
+#include "Arduino.h"
+#include "RingBuffer.h"
+
+char buffer[128];
+
+RingBuffer::RingBuffer(){
+    
+}
+
+void RingBuffer::write(char letter){
+    Serial.println("would write");
+    Serial.println(letter);
+}
+
+void RingBuffer::print(){
+    Serial.println(buffer);
+}

--- a/cnc_ctrl_v1/RingBuffer.cpp
+++ b/cnc_ctrl_v1/RingBuffer.cpp
@@ -39,9 +39,10 @@ void RingBuffer::write(char letter){
     Write one character into the ring buffer.
     
     */
-    
-    buffer[endOfString] = letter;
-    _incrementEnd();
+    if (letter != '?'){                    //ignore question marks because grbl sends them all the time
+        buffer[endOfString] = letter;
+        _incrementEnd();
+    }
 }
 
 char RingBuffer::read(){
@@ -114,9 +115,6 @@ void RingBuffer::print(){
     }
     
     Serial.println(" ");
-    
-    Serial.print("Read: ");
-    Serial.println(readLine());
     
 }
 

--- a/cnc_ctrl_v1/RingBuffer.cpp
+++ b/cnc_ctrl_v1/RingBuffer.cpp
@@ -24,16 +24,93 @@ serial data.
 #include "RingBuffer.h"
 
 char buffer[128];
+int beginningOfString = 0;             //points to the first valid character which can be read
+int endOfString = 0;                   //points to the first open space which can be written
 
 RingBuffer::RingBuffer(){
     
 }
 
 void RingBuffer::write(char letter){
-    Serial.println("would write");
-    Serial.println(letter);
+    /*
+    
+    Write one character into the ring buffer.
+    
+    */
+    
+    buffer[endOfString] = letter;
+    _incrementEnd();
+}
+
+char RingBuffer::read(){
+    /*
+    
+    Read one character from the ring buffer.
+    
+    */
+    
+    char letter;
+    if (beginningOfString == endOfString){
+        letter = '\0';                          //if the buffer is empty return null
+    }
+    else{
+        letter = buffer[beginningOfString];     //else return first charicter
+    }
+    _incrementBeginning();
+    
+    return letter;
 }
 
 void RingBuffer::print(){
-    Serial.println(buffer);
+    Serial.print("Buffer size: ");
+    Serial.println(endOfString - beginningOfString);
+    Serial.print("Begin: ");
+    Serial.println(beginningOfString);
+    Serial.print("End: ");
+    Serial.println(endOfString);
+    Serial.println("Buffer Contents: ");
+    
+    int i = beginningOfString;
+    while (i < endOfString){
+        Serial.print(buffer[i]);
+        i++;
+    }
+    
+    char temp = read();
+    
+    Serial.print("Read: ");
+    Serial.println(temp);
+    
+}
+
+void RingBuffer::_incrementBeginning(){
+    /*
+    
+    Increment the pointer to the beginning of the ring buffer by one.
+    
+    */
+    
+    if (beginningOfString == endOfString){
+        return;                             //don't allow the beginning to pass the end
+    }
+    else if (beginningOfString < 127){
+        beginningOfString++;                //move the beginning up one
+    }
+    else{
+        beginningOfString = 0;              //wrap back to zero
+    }
+}
+
+void RingBuffer::_incrementEnd(){
+    /*
+    
+    Increment the pointer to the end of the ring buffer by one.
+    
+    */
+    if (endOfString < 127){
+        endOfString++;
+    }
+    else{
+        endOfString = 0;
+    }
 }

--- a/cnc_ctrl_v1/RingBuffer.cpp
+++ b/cnc_ctrl_v1/RingBuffer.cpp
@@ -84,9 +84,6 @@ String RingBuffer::readLine(){
         i++;
     }
     
-    //Serial.print("Line detected?:");
-    //Serial.println(lineDetected);
-    
     if(lineDetected){
         char lastReadValue;
         while(lastReadValue != '\n'){                   //read until the end of the line is found, building the string
@@ -157,7 +154,7 @@ void RingBuffer::_incrementEnd(){
 int  RingBuffer::_bufferSize(){
     /*
     
-    Returns the number of charicters held in the buffer
+    Returns the number of characters held in the buffer
     
     */
     

--- a/cnc_ctrl_v1/RingBuffer.h
+++ b/cnc_ctrl_v1/RingBuffer.h
@@ -1,0 +1,33 @@
+    /*This file is part of the Maslow Control Software.
+
+    The Maslow Control Software is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Maslow Control Software is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with the Maslow Control Software.  If not, see <http://www.gnu.org/licenses/>.
+    
+    Copyright 2014-2017 Bar Smith*/
+    
+    #ifndef RingBuffer_h
+    #define RingBuffer_h
+    
+    #include "Arduino.h"
+
+    class RingBuffer{
+        public:
+            RingBuffer();
+            void write(char letter);
+            void print();
+            
+        private:
+            
+    };
+
+    #endif

--- a/cnc_ctrl_v1/RingBuffer.h
+++ b/cnc_ctrl_v1/RingBuffer.h
@@ -26,11 +26,12 @@
             void  write(char letter);
             void  print();
             char  read();
-            char* readLine();
+            String readLine();
             
         private:
             void _incrementBeginning();
             void _incrementEnd();
+            int  _bufferSize();
     };
 
     #endif

--- a/cnc_ctrl_v1/RingBuffer.h
+++ b/cnc_ctrl_v1/RingBuffer.h
@@ -23,11 +23,14 @@
     class RingBuffer{
         public:
             RingBuffer();
-            void write(char letter);
-            void print();
+            void  write(char letter);
+            void  print();
+            char  read();
+            char* readLine();
             
         private:
-            
+            void _incrementBeginning();
+            void _incrementEnd();
     };
 
     #endif

--- a/cnc_ctrl_v1/cnc_ctrl_v1.ino
+++ b/cnc_ctrl_v1/cnc_ctrl_v1.ino
@@ -42,6 +42,8 @@ void runsOnATimer(){
 
 void loop(){
     
+    readyCommandString = ringBuffer.readLine();
+    
     if (readyCommandString.length() > 0){
         readyCommandString.toUpperCase();
         interpretCommandString(readyCommandString);

--- a/cnc_ctrl_v1/cnc_ctrl_v1.ino
+++ b/cnc_ctrl_v1/cnc_ctrl_v1.ino
@@ -21,7 +21,7 @@ void setup(){
     Serial.begin(19200);
     
     Serial.println("ready");
-    Serial.println("gready");
+    Serial.println("ok");
     
     leftAxis.initializePID();
     rightAxis.initializePID();

--- a/cnc_ctrl_v1/cnc_ctrl_v1.ino
+++ b/cnc_ctrl_v1/cnc_ctrl_v1.ino
@@ -30,6 +30,8 @@ void setup(){
     Timer1.initialize(10000);
     Timer1.attachInterrupt(runsOnATimer);
     
+    Serial.println("Grbl v1.00");
+    
 }
 
 void runsOnATimer(){


### PR DESCRIPTION
Add support for using the Universal Gcode sender in place of Ground Control.

Must be merged at the same time as a similar pull request on the Ground Control side due to change to the serial protocol.