### PR TITLE
Fix for 148

### DIFF
--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -130,13 +130,11 @@ void  _watchDog(){
     This fixes the issue where the machine is ready, but Ground Control doesn't know the machine is ready and the system locks up.
     */
     static unsigned long lastRan = millis();
-    int                  timeout = 1000;
     
     if (millis() - lastRan > timeout){
-        //_signalReady();
         
-        if (!leftAxis.attached() and !rightAxis.attached and !zAxis.attached()){
-            Serial.println("now");
+        if (!leftAxis.attached() and !rightAxis.attached() and !zAxis.attached()){
+            _signalReady();
         }
         
         lastRan = millis();

--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -130,6 +130,7 @@ void  _watchDog(){
     This fixes the issue where the machine is ready, but Ground Control doesn't know the machine is ready and the system locks up.
     */
     static unsigned long lastRan = millis();
+    int                  timeout = 5000;
     
     if (millis() - lastRan > timeout){
         

--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -130,10 +130,14 @@ void  _watchDog(){
     This fixes the issue where the machine is ready, but Ground Control doesn't know the machine is ready and the system locks up.
     */
     static unsigned long lastRan = millis();
-    int                  timeout = 3000;
+    int                  timeout = 1000;
     
     if (millis() - lastRan > timeout){
         //_signalReady();
+        
+        if (!leftAxis.attached() and !rightAxis.attached and !zAxis.attached()){
+            Serial.println("now");
+        }
         
         lastRan = millis();
     }


### PR DESCRIPTION
The machine signals that it is ready for data every 5 seconds starting two seconds after the last command is finished being processed. This will resolve any situation where GC forgets that the machine is ready. Fix for issue #148 