### PR TITLE
Load machine position from memory when machine powers up

### DIFF
--- a/cnc_ctrl_v1/Kinematics.cpp
+++ b/cnc_ctrl_v1/Kinematics.cpp
@@ -179,6 +179,50 @@ void  Kinematics::inverse(float xTarget,float yTarget, float* aChainLength, floa
 
 }
 
+void  Kinematics::forward(float chainALength, float chainBLength, float* xPos, float* yPos){
+    
+    float xGuess = 0;
+    float yGuess = 0;
+    
+    float guessLengthA;
+    float guessLengthB;
+    
+    int guessCount = 0;
+    
+    while(1){
+        
+        
+        //check our guess
+        inverse(xGuess, yGuess, &guessLengthA, &guessLengthB);
+        
+        float aChainError = chainALength - guessLengthA;
+        float bChainError = chainBLength - guessLengthB;
+        
+        
+        //adjust the guess based on the result
+        xGuess = xGuess + .1*aChainError - .1*bChainError;
+        yGuess = yGuess - .1*aChainError - .1*bChainError;
+        
+        guessCount++;
+        
+        //if we've converged on the point...or it's time to give up, exit the loop
+        if((aChainError < .1 && bChainError < .1) or guessCount > 200){ 
+            Serial.println(aChainError);
+            Serial.println(bChainError);
+            break;
+        }
+        
+    }
+    
+    Serial.print("Loaded Pos: ");
+    Serial.print(xGuess);
+    Serial.print(" ");
+    Serial.println(yGuess);
+    
+    *xPos = xGuess;
+    *yPos = yGuess;
+}
+
 void  Kinematics::_MatSolv(){
     float Sum;
     int NN;

--- a/cnc_ctrl_v1/Kinematics.cpp
+++ b/cnc_ctrl_v1/Kinematics.cpp
@@ -206,9 +206,7 @@ void  Kinematics::forward(float chainALength, float chainBLength, float* xPos, f
         guessCount++;
         
         //if we've converged on the point...or it's time to give up, exit the loop
-        if((aChainError < .1 && bChainError < .1) or guessCount > 200){ 
-            Serial.println(aChainError);
-            Serial.println(bChainError);
+        if((aChainError < .1 && bChainError < .1) or guessCount > 200){
             break;
         }
         

--- a/cnc_ctrl_v1/Kinematics.h
+++ b/cnc_ctrl_v1/Kinematics.h
@@ -28,6 +28,7 @@
             Kinematics();
             void  inverse   (float xTarget,float yTarget, float* aChainLength, float* bChainLength);
             void  recomputeGeometry();
+            void  forward(float chainALength, float chainBLength, float* xPos, float* yPos);
             //geometry
             float l             = 310.0;                               //horizontal distance between sled attach points
             float s             = 139.0;                               //vertical distance between sled attach points and bit

--- a/cnc_ctrl_v1/cnc_ctrl_v1.ino
+++ b/cnc_ctrl_v1/cnc_ctrl_v1.ino
@@ -26,6 +26,9 @@ void setup(){
     Timer1.attachInterrupt(runsOnATimer);
     
     Serial.println("Grbl v1.00");
+    float temp1;
+    float temp2;
+    kinematics.forward(leftAxis.read(), rightAxis.read(), &xTarget, &yTarget);
     
 }
 


### PR DESCRIPTION
Recursively solves for the machine's position using loaded information about prevous chain lengths when the machine powers up. Partial fix for Ground Control issue #233