### PR TITLE
Print an error if command is unsuported

### DIFF
--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -709,6 +709,12 @@ void  executeGcodeLine(String gcodeLine){
         case 91:
             useRelativeUnits = true;
             break;
+        default:
+            if(gcodeLine[0] != 'B'){
+                Serial.print("Command G");
+                Serial.print(gNumber);
+                Serial.println(" unsupported and ignored.");
+            }
     }
     
 


### PR DESCRIPTION
Fix for feature request #191