### PR TITLE
Change the way ringbuffer read line works

### DIFF
--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -141,6 +141,7 @@ void  _watchDog(){
             
             if (ringBuffer.size() > 0){                  //if there is stuff sitting in the buffer, run it
                 ringBuffer.write('\n');
+                Serial.println("watch dog catch");
             }
             else{
                 _signalReady();                          //request new code

--- a/cnc_ctrl_v1/RingBuffer.cpp
+++ b/cnc_ctrl_v1/RingBuffer.cpp
@@ -71,12 +71,12 @@ String RingBuffer::readLine(){
     
     bool lineDetected = false;
     
-    int  i = 0;
-    while (i < BUFFERSIZE){                     //This will always run 128 times even if the buffer isn't full which is a waste
+    int  i = _beginningOfString;
+    while (i !=  _endOfString){                  // if we haven't gotten to the end of the buffer yet
         if(_buffer[i] == '\n'){                  //Check to see if the buffer contains a complete line terminated with \n
             lineDetected = true;
         }
-        i++;
+        _incrementVariable(&i);
     }
     
     if(lineDetected){
@@ -153,6 +153,21 @@ void RingBuffer::_incrementEnd(){
     }
     else{
         _endOfString = 0;
+    }
+}
+
+void RingBuffer::_incrementVariable(int* variable){
+    /*
+    
+    Increment the target variable.
+    
+    */
+    
+    if (*variable < BUFFERSIZE){
+        *variable = *variable + 1;                //move the variable up one
+    }
+    else{
+        *variable = 0;              //wrap back to zero
     }
 }
 

--- a/cnc_ctrl_v1/RingBuffer.h
+++ b/cnc_ctrl_v1/RingBuffer.h
@@ -35,6 +35,7 @@
         private:
             void _incrementBeginning();
             void _incrementEnd();
+            void _incrementVariable(int* variable);
             int  _beginningOfString = 0;             //points to the first valid character which can be read
             int  _endOfString       = 0;             //points to the first open space which can be written
             char _buffer[BUFFERSIZE];


### PR DESCRIPTION
Ring buffer was sometimes unable to tell if it had a complete line in memeory, and the way it checked was ineffecient.