### PR TITLE
Empty ring buffer when stop command is recieved

### DIFF
--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -174,6 +174,7 @@ bool checkForStopCommand(){
     if(stopFlag){
         readString = "";
         readyCommandString = "";
+        ringBuffer.empty();
         stopFlag = false;
         return 1;
     }

--- a/cnc_ctrl_v1/RingBuffer.cpp
+++ b/cnc_ctrl_v1/RingBuffer.cpp
@@ -198,3 +198,12 @@ int RingBuffer::spaceAvailable(){
     
     return (BUFFERSIZE - 1) - size();
 }
+
+void RingBuffer::empty(){
+    /*
+    Empty the contents of the ring buffer
+    */
+    
+    _beginningOfString = 0;
+    _endOfString       = 0;
+}

--- a/cnc_ctrl_v1/RingBuffer.h
+++ b/cnc_ctrl_v1/RingBuffer.h
@@ -30,6 +30,7 @@
             char  read();
             int   size();
             int   spaceAvailable();
+            void  empty();
             String readLine();
             
         private:


### PR DESCRIPTION
Makes the machine stop imediately instead of executing more lines