### PR TITLE
CNC_Functions.h cleanup

### DIFF
--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -391,7 +391,7 @@ void  holdPosition(){
     zAxis.hold();
 }
     
-int   findEndOfNumber(String textString, int index){
+int   findEndOfNumber(String& textString, int index){
     //Return the index of the last digit of the number beginning at the index passed in
     int i = index;
     
@@ -407,7 +407,7 @@ int   findEndOfNumber(String textString, int index){
     return i;                                                 //If we've reached the end of the string, return the last number
 }
     
-float extractGcodeValue(String readString, char target,float defaultReturn){
+float extractGcodeValue(String& readString, char target,float defaultReturn){
 
 /*Reads a string and returns the value of number following the target character.
 If no number is found, defaultReturn is returned*/
@@ -430,7 +430,7 @@ If no number is found, defaultReturn is returned*/
     return numberAsFloat;
 }
 
-int   G1(String readString){
+int   G1(String& readString){
     
 /*G1() is the function which is called to process the string if it begins with 
 'G01' or 'G00'*/
@@ -612,7 +612,7 @@ int   arc(float X1, float Y1, float X2, float Y2, float centerX, float centerY, 
     return 1;
 }
 
-int   G2(String readString){
+int   G2(String& readString){
     
     float X1 = xTarget; //does this work if units are inches? (It seems to)
     float Y1 = yTarget;
@@ -635,7 +635,7 @@ int   G2(String readString){
     }
 }
 
-void  G10(String readString){
+void  G10(String& readString){
     /*The G10() function handles the G10 gcode which re-zeros one or all of the machine's axes.*/
     
     float currentXPos = xTarget;
@@ -651,7 +651,7 @@ void  G10(String readString){
     zAxis.attach();
 }
 
-void  G38(String readString) {
+void  G38(String& readString) {
   //if the zaxis is attached
   if (zAxisAttached) {
     /*
@@ -814,7 +814,7 @@ void  printBeforeAndAfter(float before, float after){
     Serial.println(after);
 }
 
-void  updateSettings(String readString){
+void  updateSettings(String& readString){
     /*
     Updates the machine dimensions from the Ground Control settings
     */
@@ -863,7 +863,7 @@ void  updateSettings(String readString){
     Serial.println("Machine Settings Updated");
 }
 
-void  executeGcodeLine(String gcodeLine){
+void  executeGcodeLine(String& gcodeLine){
     /*
     
     Executes a single line of gcode beginning with the character 'G' or 'B'. If neither code is
@@ -1054,7 +1054,7 @@ void  executeGcodeLine(String gcodeLine){
     
 } 
 
-int   findNextG(String readString, int startingPoint){
+int   findNextG(String& readString, int startingPoint){
     int nextGIndex = readString.indexOf('G', startingPoint);
     if(nextGIndex == -1){
         nextGIndex = readString.length();
@@ -1063,7 +1063,7 @@ int   findNextG(String readString, int startingPoint){
     return nextGIndex;
 }
 
-void  interpretCommandString(String cmdString){
+void  interpretCommandString(String& cmdString){
     /*
     
     Splits a string into lines of gcode which begin with 'G'

--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -250,7 +250,10 @@ and G01 commands. The units at this point should all be in mm or mm per minute*/
     float  yDistanceToMoveInMM        = yEnd - yStartingLocation;
     
     //compute the total  number of steps in the move
-    long   finalNumberOfSteps         = abs(distanceToMoveInMM/stepSizeMM);
+    //the argument to abs should only be a variable -- splitting calc into 2 lines
+    long   finalNumberOfSteps         = distanceToMoveInMM/stepSizeMM;
+    finalNumberOfSteps = abs(finalNumberOfSteps);
+    
     
     // (fraction of distance in x direction)* size of step toward target
     float  xStepSize                  = (xDistanceToMoveInMM/distanceToMoveInMM)*stepSizeMM;
@@ -265,7 +268,7 @@ and G01 commands. The units at this point should all be in mm or mm per minute*/
     long   numberOfStepsTaken         =  0;
     long  beginingOfLastStep          = millis();
 
-    while(abs(numberOfStepsTaken) < abs(finalNumberOfSteps)){
+    while(numberOfStepsTaken < finalNumberOfSteps){
         
         //if enough time has passed to take the next step
         if (millis() - beginingOfLastStep > calculateDelay(stepSizeMM, MMPerMin)){
@@ -332,7 +335,10 @@ void  singleAxisMove(Axis* axis, float endPos, float MMPerMin){
     float direction            = -1* moveDist/abs(moveDist); //determine the direction of the move
     
     float stepSizeMM           = 0.01;                    //step size in mm
+
+    //the argument to abs should only be a variable -- splitting calc into 2 lines
     long finalNumberOfSteps    = moveDist/stepSizeMM;      //number of steps taken in move
+    finalNumberOfSteps = abs(finalNumberOfSteps);
     
     long numberOfStepsTaken    = 0;
     long  beginingOfLastStep   = millis();
@@ -345,7 +351,7 @@ void  singleAxisMove(Axis* axis, float endPos, float MMPerMin){
     //re-attach the one we want to move
     axis->attach();
     
-    while(abs(numberOfStepsTaken) < abs(finalNumberOfSteps)){
+    while(numberOfStepsTaken < finalNumberOfSteps){
         
         //reset the counter 
         beginingOfLastStep          = millis();
@@ -434,9 +440,7 @@ int   G1(String readString){
     float zgoto;
     float gospeed;
     int   isNotRapid;
-    
-    readString.toUpperCase(); //Make the string all uppercase to remove variability
-    
+        
     float currentXPos = xTarget;
     float currentYPos = yTarget;
     
@@ -532,11 +536,13 @@ int   arc(float X1, float Y1, float X2, float Y2, float centerX, float centerY, 
     float arcLengthMM            =  circumference * (theta / (2*pi) );
     
     //set up variables for movement
-    int numberOfStepsTaken       =  0;
+    long numberOfStepsTaken       =  0;
     
     float stepSizeMM             =  computeStepSize(MMPerMin);
-    int   finalNumberOfSteps     =  arcLengthMM/stepSizeMM;
-    
+
+    //the argument to abs should only be a variable -- splitting calc into 2 lines
+    long   finalNumberOfSteps     =  arcLengthMM/stepSizeMM;
+    finalNumberOfSteps = abs(finalNumberOfSteps);
     
     //Compute the starting position
     float angleNow = startingAngle;
@@ -553,7 +559,7 @@ int   arc(float X1, float Y1, float X2, float Y2, float centerX, float centerY, 
     
     long  beginingOfLastStep          = millis();
     
-    while(abs(numberOfStepsTaken) < abs(finalNumberOfSteps)){
+    while(numberOfStepsTaken < finalNumberOfSteps){
         
         //if enough time has passed to take the next step
         if (millis() - beginingOfLastStep > calculateDelay(stepSizeMM, MMPerMin)){
@@ -575,7 +581,7 @@ int   arc(float X1, float Y1, float X2, float Y2, float centerX, float centerY, 
             
             returnPoz(whereXShouldBeAtThisStep, whereYShouldBeAtThisStep, zAxis.read());
             
-            numberOfStepsTaken = numberOfStepsTaken + 1;
+            numberOfStepsTaken++;
             
             //check for new serial commands
             readSerialCommands();
@@ -656,7 +662,6 @@ void  G38(String readString) {
       Serial.println("probing for z axis zero");
       float zgoto;
 
-      readString.toUpperCase(); //Make the string all uppercase to remove variability
 
       float currentZPos = zAxis.target();
 
@@ -689,7 +694,7 @@ void  G38(String readString) {
         //        singleAxisMove(&zAxis, zgoto, feedrate);
 
         /*
-           Takes a pointer to an axis object and moves that axis to endPos at speed MMPerMin
+           Takes a pointer to an axis object and mo ves that axis to endPos at speed MMPerMin
         */
 
         Axis* axis = &zAxis;
@@ -701,7 +706,10 @@ void  G38(String readString) {
         float direction            = -1 * moveDist / abs(moveDist); //determine the direction of the move
 
         float stepSizeMM           = 0.01;                    //step size in mm
+
+        //the argument to abs should only be a variable -- splitting calc into 2 lines
         long finalNumberOfSteps    = moveDist / stepSizeMM;    //number of steps taken in move
+        finalNumberOfSteps = abs(finalNumberOfSteps);
 
         long numberOfStepsTaken    = 0;
         long  beginingOfLastStep   = millis();
@@ -709,7 +717,7 @@ void  G38(String readString) {
         axis->attach();
         //  zAxis->attach();
 
-        while (abs(numberOfStepsTaken) < abs(finalNumberOfSteps)) {
+        while (numberOfStepsTaken < finalNumberOfSteps) {
 
           //reset the counter
           beginingOfLastStep          = millis();


### PR DESCRIPTION
2 commits in this PR.

First commit:
1. Redundant uppercases removed
2. abs() changed to only supply variable as argument (required by arduino version of abs)
3. changes to while loops that were using abs in the iterators unnecessarily in CNC_Functions.h

Second commit:
1. Makes the strings, passed as parameters in CNC_Functions.h be passed by reference

On the real hardware (sans motors and encoders) everything seems to be working. 