### PR TITLE
Put back in abs() on final Number Of Steps

### DIFF
--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -583,7 +583,7 @@ int   arc(float X1, float Y1, float X2, float Y2, float centerX, float centerY, 
 
     //the argument to abs should only be a variable -- splitting calc into 2 lines
     long   finalNumberOfSteps     =  arcLengthMM/stepSizeMM;
-    finalNumberOfSteps = abs(finalNumberOfSteps);
+    //finalNumberOfSteps = abs(finalNumberOfSteps);
     
     //Compute the starting position
     float angleNow = startingAngle;
@@ -600,7 +600,7 @@ int   arc(float X1, float Y1, float X2, float Y2, float centerX, float centerY, 
     
     long  beginingOfLastStep          = millis();
     
-    while(numberOfStepsTaken < finalNumberOfSteps){
+    while(numberOfStepsTaken < abs(finalNumberOfSteps)){
         
         //if enough time has passed to take the next step
         if (millis() - beginingOfLastStep > calculateDelay(stepSizeMM, MMPerMin)){


### PR DESCRIPTION
Had to put back in the abs() on final number of steps. It appears that
it needs to be negitive some times to convey information about which way
the arc is being cut.

This should be handled in a more clear way because why the abs() is
needed is not clear from reading the code.