### PR TITLE
delay calc and machine geometry optmizing

### DIFF
--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -300,6 +300,7 @@ and G01 commands. The units at this point should all be in mm or mm per minute*/
     long   finalNumberOfSteps         = distanceToMoveInMM/stepSizeMM;
     finalNumberOfSteps = abs(finalNumberOfSteps);
     
+    float delayTime = calculateDelay(stepSizeMM, MMPerMin);
     
     // (fraction of distance in x direction)* size of step toward target
     float  xStepSize                  = (xDistanceToMoveInMM/distanceToMoveInMM)*stepSizeMM;
@@ -314,10 +315,11 @@ and G01 commands. The units at this point should all be in mm or mm per minute*/
     long   numberOfStepsTaken         =  0;
     long  beginingOfLastStep          = millis();
 
+
     while(numberOfStepsTaken < finalNumberOfSteps){
         
         //if enough time has passed to take the next step
-        if (millis() - beginingOfLastStep > calculateDelay(stepSizeMM, MMPerMin)){
+        if (millis() - beginingOfLastStep > delayTime){
             
             //reset the counter 
             beginingOfLastStep          = millis();
@@ -385,6 +387,8 @@ void  singleAxisMove(Axis* axis, float endPos, float MMPerMin){
     //the argument to abs should only be a variable -- splitting calc into 2 lines
     long finalNumberOfSteps    = moveDist/stepSizeMM;      //number of steps taken in move
     finalNumberOfSteps = abs(finalNumberOfSteps);
+
+    float delayTime = calculateDelay(stepSizeMM, MMPerMin);
     
     long numberOfStepsTaken    = 0;
     long  beginingOfLastStep   = millis();
@@ -412,7 +416,7 @@ void  singleAxisMove(Axis* axis, float endPos, float MMPerMin){
         returnPoz(xTarget, yTarget, zAxis.read());
         
         //calculate the correct delay between steps to set feedrate
-        delay(calculateDelay(stepSizeMM, MMPerMin));
+        delay(delayTime);
         
         //increment the number of steps taken
         numberOfStepsTaken++;
@@ -593,6 +597,8 @@ int   arc(float X1, float Y1, float X2, float Y2, float centerX, float centerY, 
     
     float aChainLength;
     float bChainLength;
+
+    float delayTime = calculateDelay(stepSizeMM, MMPerMin);
     
     //attach the axes
     leftAxis.attach();
@@ -603,7 +609,7 @@ int   arc(float X1, float Y1, float X2, float Y2, float centerX, float centerY, 
     while(numberOfStepsTaken < abs(finalNumberOfSteps)){
         
         //if enough time has passed to take the next step
-        if (millis() - beginingOfLastStep > calculateDelay(stepSizeMM, MMPerMin)){
+        if (millis() - beginingOfLastStep > delayTime){
             
             //reset the counter 
             beginingOfLastStep          = millis();
@@ -760,9 +766,11 @@ void  G38(String& readString) {
         long finalNumberOfSteps    = moveDist / stepSizeMM;    //number of steps taken in move
         finalNumberOfSteps = abs(finalNumberOfSteps);
 
+        float delayTime = calculateDelay(stepSizeMM, MMPerMin);
+
         long numberOfStepsTaken    = 0;
         long  beginingOfLastStep   = millis();
-
+  
         axis->attach();
         //  zAxis->attach();
 
@@ -781,7 +789,7 @@ void  G38(String& readString) {
           returnPoz(xTarget, yTarget, zAxis.read());
 
           //calculate the correct delay between steps to set feedrate
-          delay(calculateDelay(stepSizeMM, MMPerMin));
+          delay(delayTime);
 
           //increment the number of steps taken
           numberOfStepsTaken++;

--- a/cnc_ctrl_v1/Kinematics.cpp
+++ b/cnc_ctrl_v1/Kinematics.cpp
@@ -31,9 +31,6 @@ Kinematics::Kinematics(){
 void Kinematics::_verifyValidTarget(float* xTarget,float* yTarget){
     //If the target point is beyond one of the edges of the board, the machine stops at the edge
 
-    float halfWidth = machineWidth / 2.0f;
-    float halfHeight = machineHeight / 2.0f;
-
     *xTarget = (*xTarget < -halfWidth) ? -halfWidth : (*xTarget > halfWidth) ? halfWidth : *xTarget;
     *yTarget = (*yTarget < -halfHeight) ? -halfHeight : (*yTarget > halfHeight) ? halfHeight : *yTarget;
 
@@ -48,8 +45,7 @@ void Kinematics::recomputeGeometry(){
     Theta = atan(2*s/l);
     Psi1 = Theta - Phi;
     Psi2 = Theta + Phi;
-    halfWidth = machineWidth / 2.0f;
-    halfHeight = machineHeight / 2.0f;
+
 }
 
 void  Kinematics::inverse(float xTarget,float yTarget, float* aChainLength, float* bChainLength){
@@ -59,7 +55,7 @@ void  Kinematics::inverse(float xTarget,float yTarget, float* aChainLength, floa
 
     //coordinate shift to put (0,0) in the center of the plywood from the left sprocket
     x = (D/2.0) + xTarget;
-    y = (machineHeight/2.0) + motorOffsetY  - yTarget;
+    y = (halfHeight) + motorOffsetY  - yTarget;
 
     //Coordinates definition:
     //         x -->, y |

--- a/cnc_ctrl_v1/Kinematics.h
+++ b/cnc_ctrl_v1/Kinematics.h
@@ -36,9 +36,14 @@
             float h3            = 79.0;                                //distance from bit to sled center of mass
             float D             = 2978.4;                              //distance between sprocket centers
             float R             = 10.2;                                //sprocket radius
+
+
+            //machine dimensions
             float machineHeight = 1219.2;                              //this is 4 feet in mm
             float machineWidth  = 2438.4;                              //this is 8 feet in mm
             float motorOffsetY  = 463.0;                               //vertical distance from the corner of the work area to the sprocket center
+            float halfWidth = machineWidth / 2.0;                      //Half the machine width
+            float halfHeight = machineHeight / 2.0;                    //Half the machine height
             
         private:
             float _moment(float Y1Plus, float Y2Plus, float Phi, float MSinPhi, float MSinPsi1, float MCosPsi1, float MSinPsi2, float MCosPsi2);
@@ -49,9 +54,7 @@
             //target router bit coordinates.
             float x = 2708.4;
             float y = 270;
-            //machine dimensions
-            float halfWidth;
-            float halfHeight;
+
 
 
 


### PR DESCRIPTION
1) Moved delay calculations outside of while loops in CNC_Functions. No need to recalc within loop that I can find.
2) Moved machine geometry "half" calcs out of functions, to class scope. No need to recalc that I can find.