### PR TITLE
Fix right motor not turning

### DIFF
--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -314,7 +314,9 @@ and G01 commands. The units at this point should all be in mm or mm per minute*/
     long   numberOfStepsTaken         =  0;
     long  beginingOfLastStep          = millis();
 
-
+    
+    Serial.println(rightAxis.attached());
+    
     while(numberOfStepsTaken < finalNumberOfSteps){
         
         //if enough time has passed to take the next step


### PR DESCRIPTION
For some reason the compiler is optimizing out some of our functions (or
at least I think that's what's happening) printing the variables makes
them 'used' so they don't disapear, a temporary fix