### PR TITLE
Double check calibration process

### DIFF
--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -382,7 +382,11 @@ void  singleAxisMove(Axis* axis, float endPos, float MMPerMin){
     
     float startingPos          = axis->read();
     float moveDist             = startingPos - endPos; //total distance to move
-	
+    
+    Serial.print("startingPos "); Serial.println(startingPos);
+    Serial.print("endPos "); Serial.println(endPos);
+    Serial.print("moveDist "); Serial.println(moveDist);
+    
     float direction            = -1* moveDist/abs(moveDist); //determine the direction of the move
     
     float stepSizeMM           = 0.01;                    //step size in mm
@@ -1027,10 +1031,10 @@ void  executeGcodeLine(String& gcodeLine){
         
         if(useRelativeUnits){
             if(abs(lDist) > 0){
-                singleAxisMove(&leftAxis,  leftAxis.target()  + lDist, 500);
+                singleAxisMove(&leftAxis,  leftAxis.read()  + lDist, 500);
             }
             if(abs(rDist) > 0){
-                singleAxisMove(&rightAxis, rightAxis.target() + rDist, 500);
+                singleAxisMove(&rightAxis, rightAxis.read() + rDist, 500);
             }
         }
         else{

--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -383,10 +383,6 @@ void  singleAxisMove(Axis* axis, float endPos, float MMPerMin){
     float startingPos          = axis->read();
     float moveDist             = startingPos - endPos; //total distance to move
     
-    Serial.print("startingPos "); Serial.println(startingPos);
-    Serial.print("endPos "); Serial.println(endPos);
-    Serial.print("moveDist "); Serial.println(moveDist);
-    
     float direction            = -1* moveDist/abs(moveDist); //determine the direction of the move
     
     float stepSizeMM           = 0.01;                    //step size in mm
@@ -1033,15 +1029,15 @@ void  executeGcodeLine(String& gcodeLine){
         
         if(useRelativeUnits){
             if(abs(lDist) > 0){
-                singleAxisMove(&leftAxis,  leftAxis.read()  + lDist, 500);
+                singleAxisMove(&leftAxis,  leftAxis.read()  + lDist, 100);
             }
             if(abs(rDist) > 0){
-                singleAxisMove(&rightAxis, rightAxis.read() + rDist, 500);
+                singleAxisMove(&rightAxis, rightAxis.read() + rDist, 100);
             }
         }
         else{
-            singleAxisMove(&leftAxis,  lDist, 500);
-            singleAxisMove(&rightAxis, rDist, 500);
+            singleAxisMove(&leftAxis,  lDist, 100);
+            singleAxisMove(&rightAxis, rDist, 100);
         }
         
         leftAxis.setPIDAggressiveness(1);

--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -857,6 +857,8 @@ void  calibrateChainLengths(){
     Serial.print(leftAxis.read());
     Serial.println("mm");
     
+    leftAxis.detach();
+    
     //measure out the right chain
     Serial.println("Measuring out right chain");
     rightAxis.setPIDAggressiveness(.1);


### PR DESCRIPTION
Make the jog functions work off of machine position not machine target to ensure that sprockets always rotate the correct direction