### PR TITLE
Change axis.write to type void and clean up prints

### DIFF
--- a/cnc_ctrl_v1/Axis.cpp
+++ b/cnc_ctrl_v1/Axis.cpp
@@ -57,7 +57,7 @@ void   Axis::initializePID(){
     _pidController.SetSampleTime(10);
 }
 
-int    Axis::write(float targetPosition){
+void    Axis::write(float targetPosition){
     
     _pidSetpoint   =  targetPosition/_mmPerRotation;
     return 1;

--- a/cnc_ctrl_v1/Axis.h
+++ b/cnc_ctrl_v1/Axis.h
@@ -27,7 +27,7 @@
     class Axis{
         public:
             Axis(int pwmPin, int directionPin1, int directionPin2, int encoderPin1, int encoderPin2, String axisName, int eepromAdr, float mmPerRotation, float encoderSteps);
-            int    write(float targetPosition);
+            void   write(float targetPosition);
             float  read();
             int    set(float newAxisPosition);
             int    updatePositionFromEncoder();

--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -313,9 +313,6 @@ and G01 commands. The units at this point should all be in mm or mm per minute*/
     float bChainLength;
     long   numberOfStepsTaken         =  0;
     long  beginingOfLastStep          = millis();
-
-    
-    Serial.println(rightAxis.attached());
     
     while(numberOfStepsTaken < finalNumberOfSteps){
         
@@ -365,8 +362,6 @@ and G01 commands. The units at this point should all be in mm or mm per minute*/
     kinematics.inverse(xEnd,yEnd,&aChainLength,&bChainLength);
     leftAxis.endMove(aChainLength);
     rightAxis.endMove(bChainLength);
-    
-    Serial.print("Kinematics: "); Serial.print(aChainLength); Serial.print(" "); Serial.println(bChainLength);
     
     xTarget = xEnd;
     yTarget = yEnd;

--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -366,7 +366,7 @@ and G01 commands. The units at this point should all be in mm or mm per minute*/
     leftAxis.endMove(aChainLength);
     rightAxis.endMove(bChainLength);
     
-    Serial.print("Kinematics returns: "); Serial.print(aChainLength); Serial.print(" "); Serial.println(bChainLength);
+    Serial.print("Kinematics: "); Serial.print(aChainLength); Serial.print(" "); Serial.println(bChainLength);
     
     xTarget = xEnd;
     yTarget = yEnd;

--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -1163,8 +1163,10 @@ void  interpretCommandString(String& cmdString){
             
             String gcodeLine = cmdString.substring(firstG, secondG);
             
-            Serial.println(gcodeLine);
-            executeGcodeLine(gcodeLine);
+            if (gcodeLine.length() > 1){
+                Serial.println(gcodeLine);
+                executeGcodeLine(gcodeLine);
+            }
             
             cmdString = cmdString.substring(secondG, cmdString.length());
             

--- a/cnc_ctrl_v1/Kinematics.cpp
+++ b/cnc_ctrl_v1/Kinematics.cpp
@@ -173,6 +173,7 @@ void  Kinematics::forward(float chainALength, float chainBLength, float* xPos, f
     float guessLengthB;
 
     int guessCount = 0;
+    int maxNumberOfGuesses = 200;
 
     while(1){
 
@@ -200,9 +201,12 @@ void  Kinematics::forward(float chainALength, float chainBLength, float* xPos, f
         Serial.println("]");
 
         //if we've converged on the point...or it's time to give up, exit the loop
-        if((abs(aChainError) < .1 && abs(bChainError) < .1) or guessCount > 100){
-            if(guessCount > 100){
+        if((abs(aChainError) < .1 && abs(bChainError) < .1) or guessCount > maxNumberOfGuesses){
+            if(guessCount > maxNumberOfGuesses){
                 Serial.println("Message: Unable to find valid machine position. Please calibrate chain lengths.");
+                Serial.println("Lengths: ");
+                Serial.println(chainALength);
+                Serial.println(chainBLength);
                 *xPos = 0;
                 *yPos = 0;
             }

--- a/cnc_ctrl_v1/cnc_ctrl_v1.ino
+++ b/cnc_ctrl_v1/cnc_ctrl_v1.ino
@@ -12,9 +12,6 @@
     
     Copyright 2014-2017 Bar Smith*/
     
-#define SERIAL_RX_BUFFER_SIZE 512
-#define SERIAL_TX_BUFFER_SIZE 512
-    
 #include "CNC_Functions.h"
 #include "TimerOne.h"
 
@@ -31,15 +28,6 @@ void setup(){
     Timer1.attachInterrupt(runsOnATimer);
     
     Serial.println("Grbl v1.00");
-    
-    /*int i = 0;
-    String testGcode = "G20 \nG1X-1 Y-1 F100 \nG1 X1 \nG3 Y2 J1.5\nG1 X-1 \nG1 Y-1\nG1 X0 Y0\n";
-    
-    Serial.println(testGcode.length());
-    while (i < testGcode.length()){
-        ringBuffer.write(testGcode[i]);
-        i++;
-    }*/
     
 }
 


### PR DESCRIPTION
Remove a number of prints that were cluttering up the terminal and change axis.write() to be type void to prevent the compiler from "optimizing" it out of existance 