### PR TITLE
Fix PWM on pin 11 for new PCB

### DIFF
--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -177,6 +177,7 @@ void readSerialCommands(){
         char c = Serial.read();
         if (c == '!'){
             stopFlag = true;
+            pauseFlag = false;
         }
         else if (c == '~'){
             pauseFlag = false;
@@ -219,15 +220,10 @@ void pause(){
     */
     
     pauseFlag = true;
+    Serial.println("Maslow Paused");
     
     long timeLastPrinted = 0;
     while(1){
-        
-        //remind us that the machine is in the paused state
-        if (millis() - timeLastPrinted > 5000){
-            Serial.println("Maslow Paused");
-            timeLastPrinted = millis();
-        }
         
         holdPosition();
     
@@ -236,6 +232,7 @@ void pause(){
         returnPoz(xTarget, yTarget, zAxis.read());
         
         if (!pauseFlag){
+            _signalReady();
             return;
         }
     }    

--- a/cnc_ctrl_v1/Motor.cpp
+++ b/cnc_ctrl_v1/Motor.cpp
@@ -23,6 +23,7 @@ to be a drop in replacement for a continuous rotation servo.
 
 #include "Arduino.h"
 #include "Motor.h"
+#include "TimerOne.h"
 
 Motor::Motor(){
   
@@ -98,7 +99,13 @@ void Motor::write(int speed){
         
         int pwmFrequency = round(speed);
         
-        analogWrite(_pwmPin, pwmFrequency);
+        if(_pwmPin == 12){
+            pwmFrequency = map(pwmFrequency, 0, 255, 0, 1023);  //Scales 0-255 to 0-1023
+            Timer1.pwm(2, pwmFrequency);  //Special case for pin 12 due to timer blocking analogWrite()
+        }
+        else{
+            analogWrite(_pwmPin, pwmFrequency);
+        }
         
     }
 }
@@ -120,7 +127,14 @@ void Motor::directWrite(int voltage){
         digitalWrite(_pin2 , HIGH );
     }
     
-    analogWrite(_pwmPin, abs(voltage));
+    if(_pwmPin == 12){
+        voltage = abs(voltage);
+        voltage = map(voltage, 0, 255, 0, 1023);  //Scales 0-255 to 0-1023
+        Timer1.pwm(2, voltage);  //Special case for pin 12 due to timer blocking analogWrite()
+    }
+    else{
+        analogWrite(_pwmPin, abs(voltage));
+    }
 }
 
 int  Motor::attached(){

--- a/cnc_ctrl_v1/cnc_ctrl_v1.ino
+++ b/cnc_ctrl_v1/cnc_ctrl_v1.ino
@@ -21,7 +21,7 @@ void setup(){
     kinematics.forward(leftAxis.read(), rightAxis.read(), &xTarget, &yTarget);
     
     Serial.println("ready");
-    Serial.println("ok");
+    _signalReady();
     
     
     Timer1.initialize(10000);

--- a/cnc_ctrl_v1/cnc_ctrl_v1.ino
+++ b/cnc_ctrl_v1/cnc_ctrl_v1.ino
@@ -29,10 +29,6 @@ void setup(){
     
     Serial.println("Grbl v1.00");
     
-    while(true){
-        Timer1.pwm(2, 512);//leftAxis.motorGearboxEncoder.motor.directWrite(255);
-    }
-    
 }
 
 void runsOnATimer(){

--- a/cnc_ctrl_v1/cnc_ctrl_v1.ino
+++ b/cnc_ctrl_v1/cnc_ctrl_v1.ino
@@ -29,6 +29,10 @@ void setup(){
     
     Serial.println("Grbl v1.00");
     
+    while(true){
+        Timer1.pwm(2, 512);//leftAxis.motorGearboxEncoder.motor.directWrite(255);
+    }
+    
 }
 
 void runsOnATimer(){


### PR DESCRIPTION
The timer1 library disables PWM on pin 11 which we use to drive the left motor on the new PCB (bummer). This PR fixes the issue by using the timer1 library PWM module instead of the arduino PWM module.