### PR TITLE
Fix for buffer overflow when using manual z-axis

### DIFF
--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -288,7 +288,6 @@ void pause(){
         returnPoz(xTarget, yTarget, zAxis.read());
         
         if (!pauseFlag){
-            _signalReady();
             return;
         }
     }    


### PR DESCRIPTION
When the manual z-axis was triggered, it was signaling that it needed
one extra line of g-code, eventually leading to buffer overflow