### PR TITLE
Fix ZAxis Feedrate and Calculation of Total Distance

### DIFF
--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -432,7 +432,7 @@ void  singleAxisMove(Axis* axis, const float& endPos, const float& MMPerMin){
     float startingPos          = axis->read();
     float moveDist             = endPos - startingPos; //total distance to move
     
-    float direction            = -1* moveDist/abs(moveDist); //determine the direction of the move
+    float direction            = moveDist/abs(moveDist); //determine the direction of the move
     
     float stepSizeMM           = 0.01;                    //step size in mm
 
@@ -810,7 +810,7 @@ void  G38(const String& readString) {
         float endPos               = zgoto;
         float moveDist             = endPos - currentZPos; //total distance to move
 
-        float direction            = -1 * moveDist / abs(moveDist); //determine the direction of the move
+        float direction            = moveDist / abs(moveDist); //determine the direction of the move
 
         float stepSizeMM           = 0.01;                    //step size in mm
 

--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -563,7 +563,13 @@ int   G1(const String& readString){
     if(zAxisAttached){
         float threshold = .01;
         if (abs(zgoto- currentZPos) > threshold){
-            float zfeedrate = constrain(feedrate, 1, MAXZROTMIN * ZDISTPERROT);
+            float zfeedrate
+            if (isNotRapid) {
+                zfeedrate = constrain(feedrate, 1, MAXZROTMIN * ZDISTPERROT);
+            }
+            else {
+                zfeedrate = MAXZROTMIN * ZDISTPERROT;
+            }
             singleAxisMove(&zAxis, zgoto, zfeedrate);
         }
     }

--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -430,7 +430,7 @@ void  singleAxisMove(Axis* axis, const float& endPos, const float& MMPerMin){
     */
     
     float startingPos          = axis->read();
-    float moveDist             = startingPos - endPos; //total distance to move
+    float moveDist             = endPos - startingPos; //total distance to move
     
     float direction            = -1* moveDist/abs(moveDist); //determine the direction of the move
     
@@ -808,7 +808,7 @@ void  G38(const String& readString) {
         float MMPerMin             = feedrate;
         float startingPos          = axis->target();
         float endPos               = zgoto;
-        float moveDist             = currentZPos - endPos; //total distance to move
+        float moveDist             = endPos - currentZPos; //total distance to move
 
         float direction            = -1 * moveDist / abs(moveDist); //determine the direction of the move
 

--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -37,6 +37,7 @@ bool zAxisAttached = false;
 #define MILLIMETERS 1
 #define INCHES      25.4
 #define MAXFEED     900      //The maximum allowable feedrate in mm/min
+#define MAXZROTMIN  12.60    // the maximum z rotations per minute
 
 
 int ENCODER1A;
@@ -562,7 +563,8 @@ int   G1(const String& readString){
     if(zAxisAttached){
         float threshold = .01;
         if (abs(zgoto- currentZPos) > threshold){
-            singleAxisMove(&zAxis, zgoto,45);
+            float zfeedrate = constrain(feedrate, 1, MAXZROTMIN * ZDISTPERROT);
+            singleAxisMove(&zAxis, zgoto, zfeedrate);
         }
     }
     else{
@@ -774,6 +776,7 @@ void  G38(const String& readString) {
 
       zgoto      = _inchesToMMConversion * extractGcodeValue(readString, 'Z', currentZPos / _inchesToMMConversion);
       feedrate   = _inchesToMMConversion * extractGcodeValue(readString, 'F', feedrate / _inchesToMMConversion);
+      feedrate = constrain(feedrate, 1, MAXZROTMIN * ZDISTPERROT);
 
       if (useRelativeUnits) { //if we are using a relative coordinate system
         if (readString.indexOf('Z') >= 0) { //if z has moved


### PR DESCRIPTION
Fixed the calculation of moveDist which if the starting depth was negative and the finishing depth was positive was returning the wrong value.

Also discovered that the hardcoded feedrate for zaxis moves of 45mm/min was too much for my motor to keep up with.  I believe this was the main cause for the incomplete retraction before moving.

Now, the feedrate can be set by Gcode, but its upper bound is limited by the rpm of the motor.  With the stock motor this results in a feedrate of about 40mm/min.  But this number will adjust based on the pitch of the zaxis setting.

Fixes #266 
