### PR TITLE
Fix Calculation of Angle in Arc Function

### DIFF
--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -631,11 +631,17 @@ int   arc(const float& X1, const float& Y1, const float& X2, const float& Y2, co
     float endingAngle            =  atan2(Y2 - centerY, X2 - centerX);
     
     //compute angle between lines
-    float theta                  =  abs(startingAngle) - abs(endingAngle);
-    
-    //Catch the corner case where the beginning and end of the circle are the same
-    if (startingAngle == endingAngle){
-        theta = direction*2*pi;
+    float theta                  =  endingAngle - startingAngle;
+    if (direction == COUNTERCLOCKWISE){
+        if (theta <= 0){
+            theta += 2*pi;
+        }
+    }
+    else {
+        //CLOCKWISE
+        if (theta >= 0){
+            theta -= 2*pi;
+        }
     }
     
     float arcLengthMM            =  circumference * (theta / (2*pi) );


### PR DESCRIPTION
The calculation of theta was wrong.  A good example was theta would equal zero for any cut in quadrant 2 ending in quadrant 3, where the start and end angles were the same.

To fix:
1. flip the calculation so it is ending point minus starting point.
2. The values of atan2 are between -pi and pi.  So we need to normalize to 2pi

No longer need to specifically catch the edge case of a full circle as this is now caught as part of the regular processing.

Fixes #268 