### PR TITLE
Reduce string memory use

### DIFF
--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -20,7 +20,7 @@ libraries*/
 #include "Kinematics.h"
 #include "RingBuffer.h"
 
-#define VERSIONNUMBER 0.81
+#define VERSIONNUMBER 0.82
 
 bool zAxisAttached = false;
 
@@ -139,8 +139,9 @@ float _inchesToMMConversion =  1;
 bool  useRelativeUnits      =  false;
 bool  stopFlag              =  false;
 bool  pauseFlag             =  false;
-String readString;                        //command being built one character at a time
 String readyCommandString;                //next command queued up and ready to send
+String gcodeLine;                         //The next individual line of gcode (for example G91 G01 X19 would be run as two lines)
+
 int   lastCommand           =  0;         //Stores the value of the last command run eg: G01 -> 1
 
 //These are used in place of a forward kinematic function at the beginning of each move. They should be replaced
@@ -252,7 +253,6 @@ bool checkForStopCommand(){
     Check to see if the STOP command has been sent to the machine.
     */
     if(stopFlag){
-        readString = "";
         readyCommandString = "";
         ringBuffer.empty();
         stopFlag = false;
@@ -301,7 +301,6 @@ bool checkForProbeTouch(const int& probePin) {
       Check to see if AUX4 has gone LOW
   */
   if (digitalRead(probePin) == LOW) {
-    readString = "";
     readyCommandString = "";
     return 1;
   }
@@ -1225,7 +1224,7 @@ void  interpretCommandString(const String& cmdString){
                 firstG = 0;                     //send the whole line
             }
             
-            String gcodeLine = cmdString.substring(firstG, secondG);
+            gcodeLine = cmdString.substring(firstG, secondG);
             
             if (gcodeLine.length() > 1){
                 Serial.println(gcodeLine);

--- a/cnc_ctrl_v1/RingBuffer.cpp
+++ b/cnc_ctrl_v1/RingBuffer.cpp
@@ -68,7 +68,7 @@ String RingBuffer::readLine(){
     */
     
     String lineToReturn;
-    lineToReturn.reserve(60);
+    lineToReturn.reserve(128);
     
     bool lineDetected = false;
     

--- a/cnc_ctrl_v1/RingBuffer.cpp
+++ b/cnc_ctrl_v1/RingBuffer.cpp
@@ -68,6 +68,7 @@ String RingBuffer::readLine(){
     */
     
     String lineToReturn;
+    lineToReturn.reserve(60);
     
     bool lineDetected = false;
     

--- a/cnc_ctrl_v1/cnc_ctrl_v1.ino
+++ b/cnc_ctrl_v1/cnc_ctrl_v1.ino
@@ -18,8 +18,8 @@
 void setup(){
     Serial.begin(57600);
     
-    readyCommandString.reserve(60);           //Allocate memory so that this string doesn't fragment the heap as it grows and shrinks
-    gcodeLine.reserve(60);
+    readyCommandString.reserve(128);           //Allocate memory so that this string doesn't fragment the heap as it grows and shrinks
+    gcodeLine.reserve(128);
     
     kinematics.forward(leftAxis.read(), rightAxis.read(), &xTarget, &yTarget);
     

--- a/cnc_ctrl_v1/cnc_ctrl_v1.ino
+++ b/cnc_ctrl_v1/cnc_ctrl_v1.ino
@@ -18,6 +18,9 @@
 void setup(){
     Serial.begin(57600);
     
+    readyCommandString.reserve(60);           //Allocate memory so that this string doesn't fragment the heap as it grows and shrinks
+    gcodeLine.reserve(60);
+    
     kinematics.forward(leftAxis.read(), rightAxis.read(), &xTarget, &yTarget);
     
     if(pcbRevisionIndicator == 0){


### PR DESCRIPTION
Reserve space for strings to prevent stack fragmentation