### PR TITLE
Reduce Ki value to 1

### DIFF
--- a/cnc_ctrl_v1/MotorGearboxEncoder.h
+++ b/cnc_ctrl_v1/MotorGearboxEncoder.h
@@ -42,9 +42,9 @@
             float      _runningAverage(const int& newValue);
             String     _motorName;
             double     _pidOutput;
-            double     _Kp=20, _Ki=5, _Kd=0;
             PID        _posPIDController;
             PID        _negPIDController;
+            double     _Kp=20, _Ki=1, _Kd=0;
             int        _oldValue1;
             int        _oldValue2;
             int        _oldValue3;


### PR DESCRIPTION
The integrator was saturating resulting in jerky movements