### PR TITLE
Load PID values from ground control

### DIFF
--- a/cnc_ctrl_v1/Axis.cpp
+++ b/cnc_ctrl_v1/Axis.cpp
@@ -26,7 +26,7 @@
 #define SIZEOFFLOAT      4
 #define SIZEOFLINSEG    17
 
-Axis::Axis(const int& pwmPin, const int& directionPin1, const int& directionPin2, const int& encoderPin1, const int& encoderPin2, const String& axisName, const int& eepromAdr, const float& mmPerRotation, const float& encoderSteps)
+Axis::Axis(const int& pwmPin, const int& directionPin1, const int& directionPin2, const int& encoderPin1, const int& encoderPin2, const String& axisName, const int& eepromAdr)
 :
 motorGearboxEncoder(pwmPin, directionPin1, directionPin2, encoderPin1, encoderPin2)
 {
@@ -38,12 +38,15 @@ motorGearboxEncoder(pwmPin, directionPin1, directionPin2, encoderPin1, encoderPi
     _axisName     = axisName;
     _axisTarget   = 0.0;
     _eepromAdr    = eepromAdr;
-    _mmPerRotation= mmPerRotation;
-    _encoderSteps = encoderSteps;
     
     //load position
     if (EEPROM.read(_eepromAdr) == EEPROMVALIDDATA){
         set(_readFloat(_eepromAdr + SIZEOFFLOAT));
+        
+        Serial.print("Read from memory: ");
+        Serial.print(_axisName);
+        Serial.print(": ");
+        Serial.println(_readFloat(_eepromAdr + SIZEOFFLOAT));
     }
     
     initializePID();
@@ -65,6 +68,11 @@ void    Axis::write(const float& targetPosition){
 
 float  Axis::read(){
     //returns the true axis position
+    
+    Serial.println("Read scale: ");
+    Serial.println(_encoderSteps);
+    Serial.println(_mmPerRotation);
+    
     return (motorGearboxEncoder.encoder.read()/_encoderSteps)*_mmPerRotation;
 }
 
@@ -78,6 +86,11 @@ float  Axis::setpoint(){
 }
 
 int    Axis::set(const float& newAxisPosition){
+    
+    Serial.print("Set: ");
+    Serial.print(_axisName);
+    Serial.print(" ");
+    Serial.println(newAxisPosition);
     
     //reset everything to the new value
     _axisTarget   =  newAxisPosition/_mmPerRotation;

--- a/cnc_ctrl_v1/Axis.cpp
+++ b/cnc_ctrl_v1/Axis.cpp
@@ -31,7 +31,7 @@ Axis::Axis(const int& pwmPin, const int& directionPin1, const int& directionPin2
 motorGearboxEncoder(pwmPin, directionPin1, directionPin2, encoderPin1, encoderPin2)
 {
     
-    _pidController.setup(&_pidInput, &_pidOutput, &_pidSetpoint, _Kp, _Ki, _Kd, REVERSE);
+    _pidController.setup(&_pidInput, &_pidOutput, &_pidSetpoint, 0, 0, 0, REVERSE);
     
     //initialize variables
     _direction    = FORWARD;
@@ -53,11 +53,6 @@ void   Axis::loadPositionFromMemory(){
         //If a valid position has been stored
         if (EEPROM.read(_eepromAdr) == EEPROMVALIDDATA){
             set(_readFloat(_eepromAdr + SIZEOFFLOAT));
-            
-            Serial.print("Read from memory: ");
-            Serial.print(_axisName);
-            Serial.print(": ");
-            Serial.println(_readFloat(_eepromAdr + SIZEOFFLOAT));
         }
 }
 
@@ -68,19 +63,14 @@ void   Axis::initializePID(){
 }
 
 void    Axis::write(const float& targetPosition){
-    
-    _pidSetpoint   =  targetPosition/_mmPerRotation;
+    if(_mmPerRotation!= 0){
+        _pidSetpoint   =  targetPosition/_mmPerRotation;
+    }
     return;
 }
 
 float  Axis::read(){
     //returns the true axis position
-    
-    //Serial.println("Read scale: ");
-    //Serial.println(_encoderSteps);
-    //Serial.println(_mmPerRotation);
-    //Serial.println(motorGearboxEncoder.encoder.read());
-    //Serial.println((motorGearboxEncoder.encoder.read()/_encoderSteps)*_mmPerRotation);
     
     return (motorGearboxEncoder.encoder.read()/_encoderSteps)*_mmPerRotation;
 }
@@ -95,13 +85,6 @@ float  Axis::setpoint(){
 }
 
 int    Axis::set(const float& newAxisPosition){
-    
-    Serial.print("Set: ");
-    Serial.print(_axisName);
-    Serial.print(" ");
-    Serial.println(newAxisPosition);
-    Serial.println(_encoderSteps);
-    Serial.println(_mmPerRotation);
     
     //reset everything to the new value
     _axisTarget   =  newAxisPosition/_mmPerRotation;
@@ -128,8 +111,13 @@ void   Axis::computePID(){
     motorGearboxEncoder.write(_pidOutput);
     
     /*if(_axisName[0] == 'L'){
+        Serial.println("*");
+        Serial.println(_pidInput);
+        Serial.println(_pidSetpoint);
         Serial.println(_pidOutput);
     }*/
+    
+    
     
     motorGearboxEncoder.computePID();
     

--- a/cnc_ctrl_v1/Axis.cpp
+++ b/cnc_ctrl_v1/Axis.cpp
@@ -111,6 +111,19 @@ void   Axis::computePID(){
     
 }
 
+void   Axis::setPIDValues(float Kp, float Ki, float Kd){
+    /*
+    
+    Sets the positional PID values for the axis
+    
+    */
+    _Kp = Kp;
+    _Ki = Ki;
+    _Kd = Kd;
+    
+    _pidController.SetTunings(_Kp, _Ki, _Kd);
+}
+
 void   Axis::setPIDAggressiveness(float aggressiveness){
     /*
     

--- a/cnc_ctrl_v1/Axis.cpp
+++ b/cnc_ctrl_v1/Axis.cpp
@@ -111,17 +111,19 @@ void   Axis::computePID(){
     
 }
 
-void   Axis::setPIDValues(float Kp, float Ki, float Kd){
+void   Axis::setPIDValues(float KpPos, float KiPos, float KdPos, float KpV, float KiV, float KdV){
     /*
     
     Sets the positional PID values for the axis
     
     */
-    _Kp = Kp;
-    _Ki = Ki;
-    _Kd = Kd;
+    _Kp = KpPos;
+    _Ki = KiPos;
+    _Kd = KdPos;
     
     _pidController.SetTunings(_Kp, _Ki, _Kd);
+    
+    motorGearboxEncoder.setPIDValues(KpV, KiV, KdV);
 }
 
 void   Axis::setPIDAggressiveness(float aggressiveness){

--- a/cnc_ctrl_v1/Axis.cpp
+++ b/cnc_ctrl_v1/Axis.cpp
@@ -63,9 +63,8 @@ void   Axis::initializePID(){
 }
 
 void    Axis::write(const float& targetPosition){
-    if(_mmPerRotation!= 0){
-        _pidSetpoint   =  targetPosition/_mmPerRotation;
-    }
+    
+    _pidSetpoint   =  targetPosition/_mmPerRotation;
     return;
 }
 

--- a/cnc_ctrl_v1/Axis.cpp
+++ b/cnc_ctrl_v1/Axis.cpp
@@ -36,22 +36,29 @@ motorGearboxEncoder(pwmPin, directionPin1, directionPin2, encoderPin1, encoderPi
     //initialize variables
     _direction    = FORWARD;
     _axisName     = axisName;
-    _axisTarget   = 0.0;
     _eepromAdr    = eepromAdr;
-    
-    //load position
-    if (EEPROM.read(_eepromAdr) == EEPROMVALIDDATA){
-        set(_readFloat(_eepromAdr + SIZEOFFLOAT));
-        
-        Serial.print("Read from memory: ");
-        Serial.print(_axisName);
-        Serial.print(": ");
-        Serial.println(_readFloat(_eepromAdr + SIZEOFFLOAT));
-    }
     
     initializePID();
     
     motorGearboxEncoder.setName(_axisName);
+}
+
+void   Axis::loadPositionFromMemory(){
+        /*
+        
+        Reload the last known position for the axis
+        
+        */
+        
+        //If a valid position has been stored
+        if (EEPROM.read(_eepromAdr) == EEPROMVALIDDATA){
+            set(_readFloat(_eepromAdr + SIZEOFFLOAT));
+            
+            Serial.print("Read from memory: ");
+            Serial.print(_axisName);
+            Serial.print(": ");
+            Serial.println(_readFloat(_eepromAdr + SIZEOFFLOAT));
+        }
 }
 
 void   Axis::initializePID(){
@@ -69,9 +76,11 @@ void    Axis::write(const float& targetPosition){
 float  Axis::read(){
     //returns the true axis position
     
-    Serial.println("Read scale: ");
-    Serial.println(_encoderSteps);
-    Serial.println(_mmPerRotation);
+    //Serial.println("Read scale: ");
+    //Serial.println(_encoderSteps);
+    //Serial.println(_mmPerRotation);
+    //Serial.println(motorGearboxEncoder.encoder.read());
+    //Serial.println((motorGearboxEncoder.encoder.read()/_encoderSteps)*_mmPerRotation);
     
     return (motorGearboxEncoder.encoder.read()/_encoderSteps)*_mmPerRotation;
 }
@@ -91,6 +100,8 @@ int    Axis::set(const float& newAxisPosition){
     Serial.print(_axisName);
     Serial.print(" ");
     Serial.println(newAxisPosition);
+    Serial.println(_encoderSteps);
+    Serial.println(_mmPerRotation);
     
     //reset everything to the new value
     _axisTarget   =  newAxisPosition/_mmPerRotation;

--- a/cnc_ctrl_v1/Axis.h
+++ b/cnc_ctrl_v1/Axis.h
@@ -47,7 +47,7 @@
             bool   attached();
             void   wipeEEPROM();
             MotorGearboxEncoder    motorGearboxEncoder;
-            void   setPIDValues(float Kp, float Ki, float Kd);
+            void   setPIDValues(float Kp, float Ki, float Kd, float KpV, float KiV, float KdV);
             
         private:
             int        _PWMread(int pin);

--- a/cnc_ctrl_v1/Axis.h
+++ b/cnc_ctrl_v1/Axis.h
@@ -61,14 +61,12 @@
             int        _currentAngle;
             int        _previousAngle;
             double     _timeLastMoved;
-            double     _pidSetpoint = 0;
-            double     _pidInput = 0;
-            double     _pidOutput = 0;
+            double     _pidSetpoint, _pidInput, _pidOutput;
             double     _Kp=0, _Ki = 0, _Kd=0;
             PID        _pidController;
             int        _eepromAdr;
             float      _mmPerRotation = 1;
-            float      _encoderSteps = 1000;
+            float      _encoderSteps  = 100;
             float      _oldSetpoint;
             float      _oldDir;
             bool       _disableAxisForTesting = false;

--- a/cnc_ctrl_v1/Axis.h
+++ b/cnc_ctrl_v1/Axis.h
@@ -26,8 +26,8 @@
 
     class Axis{
         public:
-            Axis(const int& pwmPin, const int& directionPin1, const int& directionPin2, const int& encoderPin1, const int& encoderPin2, const String& axisName, const int& eepromAdr, const float& mmPerRotation, const float& encoderSteps);
-            void    write(const float& targetPosition);
+            Axis(const int& pwmPin, const int& directionPin1, const int& directionPin2, const int& encoderPin1, const int& encoderPin2, const String& axisName, const int& eepromAdr);
+            void   write(const float& targetPosition);
             float  read();
             int    set(const float& newAxisPosition);
             int    updatePositionFromEncoder();

--- a/cnc_ctrl_v1/Axis.h
+++ b/cnc_ctrl_v1/Axis.h
@@ -61,7 +61,7 @@
             int        _previousAngle;
             double     _timeLastMoved;
             double     _pidSetpoint, _pidInput, _pidOutput;
-            double     _Kp=400, _Ki = 5, _Kd=10;
+            double     _Kp=0, _Ki = 0, _Kd=0;
             PID        _pidController;
             int        _eepromAdr;
             float      _mmPerRotation;

--- a/cnc_ctrl_v1/Axis.h
+++ b/cnc_ctrl_v1/Axis.h
@@ -47,7 +47,7 @@
             bool   attached();
             void   wipeEEPROM();
             MotorGearboxEncoder    motorGearboxEncoder;
-            String     _axisName;
+            void   setPIDValues(float Kp, float Ki, float Kd);
             
         private:
             int        _PWMread(int pin);
@@ -69,6 +69,7 @@
             float      _oldSetpoint;
             float      _oldDir;
             bool       _disableAxisForTesting = false;
+            String     _axisName;
     };
 
     #endif

--- a/cnc_ctrl_v1/Axis.h
+++ b/cnc_ctrl_v1/Axis.h
@@ -48,6 +48,7 @@
             void   wipeEEPROM();
             MotorGearboxEncoder    motorGearboxEncoder;
             void   setPIDValues(float Kp, float Ki, float Kd, float KpV, float KiV, float KdV);
+            void   loadPositionFromMemory();
             
         private:
             int        _PWMread(int pin);

--- a/cnc_ctrl_v1/Axis.h
+++ b/cnc_ctrl_v1/Axis.h
@@ -61,12 +61,14 @@
             int        _currentAngle;
             int        _previousAngle;
             double     _timeLastMoved;
-            double     _pidSetpoint, _pidInput, _pidOutput;
+            double     _pidSetpoint = 0;
+            double     _pidInput = 0;
+            double     _pidOutput = 0;
             double     _Kp=0, _Ki = 0, _Kd=0;
             PID        _pidController;
             int        _eepromAdr;
-            float      _mmPerRotation;
-            float      _encoderSteps;
+            float      _mmPerRotation = 1;
+            float      _encoderSteps = 1000;
             float      _oldSetpoint;
             float      _oldDir;
             bool       _disableAxisForTesting = false;

--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -972,7 +972,7 @@ void  updateSettings(const String& readString){
     float KdV                = extractGcodeValue(readString, 'X', -1);
     
     //Write the PID values to the axis if new ones have been received
-    if (KpPos != -1 or KiPos != -1 or KdPos != -1){
+    if (KpPos != -1){
         leftAxis.setPIDValues(KpPos, KiPos, KdPos, KpV, KiV, KdV);
         rightAxis.setPIDValues(KpPos, KiPos, KdPos, KpV, KiV, KdV);
         zAxis.setPIDValues(KpPos, KiPos, KdPos, KpV, KiV, KdV);

--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -973,9 +973,9 @@ void  updateSettings(const String& readString){
     
     //Write the PID values to the axies if new ones have been received
     if (KpPos != 0 or KiPos != 0 or KdPos != 0){
-        leftAxis.setPIDValues(KpPos, KiPos, KdPos);
-        rightAxis.setPIDValues(KpPos, KiPos, KdPos);
-        zAxis.setPIDValues(KpPos, KiPos, KdPos);
+        leftAxis.setPIDValues(KpPos, KiPos, KdPos, KpV, KiV, KdV);
+        rightAxis.setPIDValues(KpPos, KiPos, KdPos, KpV, KiV, KdV);
+        zAxis.setPIDValues(KpPos, KiPos, KdPos, KpV, KiV, KdV);
     }
     
     //Change the motor properties in cnc_funtions

--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -58,10 +58,11 @@ int ENA;
 int ENB;
 int ENC;
 
-#define DISTPERROT     10*6.35//#teeth*pitch of chain
-#define ZDISTPERROT    3.17//1/8inch in mm
-#define ENCODERSTEPS   8148.0 //7*291*4 --- 7ppr, 291:1 gear ratio, quadrature encoding
-#define ZENCODERSTEPS  7560.0 //7*270*4 --- 7ppr, 270:1 gear ratio, quadrature encoding
+//These are set in Ground Control now
+//#define DISTPERROT     10*6.35//#teeth*pitch of chain
+//#define ZDISTPERROT    3.17//1/8inch in mm
+//#define ENCODERSTEPS   8148.0 //7*291*4 --- 7ppr, 291:1 gear ratio, quadrature encoding
+//#define ZENCODERSTEPS  7560.0 //7*270*4 --- 7ppr, 270:1 gear ratio, quadrature encoding
 
 #define AUX1 17
 #define AUX2 16
@@ -126,9 +127,9 @@ int   setupPins(){
 
 int pinsSetup       = setupPins();
 
-Axis leftAxis (ENC, IN6, IN5, ENCODER3B, ENCODER3A, "L",  LEFT_EEPROM_ADR, DISTPERROT , ENCODERSTEPS);
-Axis rightAxis(ENA, IN1, IN2, ENCODER1A, ENCODER1B, "R", RIGHT_EEPROM_ADR, DISTPERROT , ENCODERSTEPS);
-Axis zAxis    (ENB, IN3, IN4, ENCODER2B, ENCODER2A, "Z",     Z_EEPROM_ADR, ZDISTPERROT, ZENCODERSTEPS);
+Axis leftAxis (ENC, IN6, IN5, ENCODER3B, ENCODER3A, "L",  LEFT_EEPROM_ADR);
+Axis rightAxis(ENA, IN1, IN2, ENCODER1A, ENCODER1B, "R", RIGHT_EEPROM_ADR);
+Axis zAxis    (ENB, IN3, IN4, ENCODER2B, ENCODER2A, "Z",     Z_EEPROM_ADR);
 
 
 Kinematics kinematics;
@@ -561,10 +562,10 @@ int   G1(const String& readString, int G0orG1){
         if (abs(zgoto- currentZPos) > threshold){
             float zfeedrate;
             if (G0orG1 == 1) {
-                zfeedrate = constrain(feedrate, 1, MAXZROTMIN * ZDISTPERROT);
+                zfeedrate = constrain(feedrate, 1, MAXZROTMIN * 3.17);//distance per rotation shouldn't be hard coded here
             }
             else {
-                zfeedrate = MAXZROTMIN * ZDISTPERROT;
+                zfeedrate = MAXZROTMIN * 3.17;
             }
             singleAxisMove(&zAxis, zgoto, zfeedrate);
         }
@@ -784,7 +785,7 @@ void  G38(const String& readString) {
 
       zgoto      = _inchesToMMConversion * extractGcodeValue(readString, 'Z', currentZPos / _inchesToMMConversion);
       feedrate   = _inchesToMMConversion * extractGcodeValue(readString, 'F', feedrate / _inchesToMMConversion);
-      feedrate = constrain(feedrate, 1, MAXZROTMIN * ZDISTPERROT);
+      feedrate = constrain(feedrate, 1, MAXZROTMIN * 3.17);
 
       if (useRelativeUnits) { //if we are using a relative coordinate system
         if (readString.indexOf('Z') >= 0) { //if z has moved
@@ -923,7 +924,7 @@ void  calibrateChainLengths(){
     Serial.print(rightAxis.read());
     Serial.println(F("mm"));
     
-    kinematics.forward(leftAxis.read(), rightAxis.read(), &xTarget, &yTarget);
+    //kinematics.forward(leftAxis.read(), rightAxis.read(), &xTarget, &yTarget);
     
     
     leftAxis.setPIDAggressiveness(1);
@@ -948,55 +949,79 @@ void  updateSettings(const String& readString){
     
     //Extract the settings values
 
-    float bedWidth           = extractGcodeValue(readString, 'A', kinematics.machineWidth);
-    float bedHeight          = extractGcodeValue(readString, 'C', kinematics.machineHeight);
-    float distBetweenMotors  = extractGcodeValue(readString, 'Q', kinematics.D);
-    float motorOffsetX       = extractGcodeValue(readString, 'D', (distBetweenMotors - bedWidth)/2); //read the motor offset X IF it is sent, if it's not sent, compute it from the spacing between the motors
-    float motorOffsetY       = extractGcodeValue(readString, 'E', motorOffsetY);
-    float sledWidth          = extractGcodeValue(readString, 'F', kinematics.l);
-    float sledHeight         = extractGcodeValue(readString, 'R', kinematics.s);
-    float sledCG             = extractGcodeValue(readString, 'H', kinematics.h3);
-    zAxisAttached            = extractGcodeValue(readString, 'I', zAxisAttached);
-    int encoderSteps         = extractGcodeValue(readString, 'J', ENCODERSTEPS);
-    float gearTeeth          = extractGcodeValue(readString, 'K', 10);
-    float chainPitch         = extractGcodeValue(readString, 'M', 6.35);
+    float bedWidth           = extractGcodeValue(readString, 'A', -1);
+    float bedHeight          = extractGcodeValue(readString, 'C', -1);
+    float motorOffsetY       = extractGcodeValue(readString, 'E', -1);
+    float sledWidth          = extractGcodeValue(readString, 'F', -1);
+    float sledHeight         = extractGcodeValue(readString, 'R', -1);
+    float sledCG             = extractGcodeValue(readString, 'H', -1);
+    zAxisAttached            = extractGcodeValue(readString, 'I', -1);
+    int encoderSteps         = extractGcodeValue(readString, 'J', -1);
+    float gearTeeth          = extractGcodeValue(readString, 'K', -1);
+    float chainPitch         = extractGcodeValue(readString, 'M', -1);
     
-    float zDistPerRot        = extractGcodeValue(readString, 'N', ZDISTPERROT);
-    int zEncoderSteps        = extractGcodeValue(readString, 'P', ZENCODERSTEPS);
+    float zDistPerRot        = extractGcodeValue(readString, 'N', -1);
+    int zEncoderSteps        = extractGcodeValue(readString, 'P', -1);
     
-    float KpPos              = extractGcodeValue(readString, 'S', 0);
-    float KiPos              = extractGcodeValue(readString, 'T', 0);
-    float KdPos              = extractGcodeValue(readString, 'U', 0);
-    float KpV                = extractGcodeValue(readString, 'V', 0);
-    float KiV                = extractGcodeValue(readString, 'W', 0);
-    float KdV                = extractGcodeValue(readString, 'X', 0);
+    float KpPos              = extractGcodeValue(readString, 'S', -1);
+    float KiPos              = extractGcodeValue(readString, 'T', -1);
+    float KdPos              = extractGcodeValue(readString, 'U', -1);
+    float KpV                = extractGcodeValue(readString, 'V', -1);
+    float KiV                = extractGcodeValue(readString, 'W', -1);
+    float KdV                = extractGcodeValue(readString, 'X', -1);
     
-    //Write the PID values to the axies if new ones have been received
-    if (KpPos != 0 or KiPos != 0 or KdPos != 0){
+    //Write the PID values to the axis if new ones have been received
+    if (KpPos != -1 or KiPos != -1 or KdPos != -1){
         leftAxis.setPIDValues(KpPos, KiPos, KdPos, KpV, KiV, KdV);
         rightAxis.setPIDValues(KpPos, KiPos, KdPos, KpV, KiV, KdV);
         zAxis.setPIDValues(KpPos, KiPos, KdPos, KpV, KiV, KdV);
     }
     
-    //Change the motor properties in cnc_funtions
-    float distPerRot = gearTeeth*chainPitch; 
-    leftAxis.changePitch(distPerRot);
-    rightAxis.changePitch(distPerRot);
-    zAxis.changePitch(zDistPerRot);
+    //Change the motor properties in cnc_funtions if new values have been sent
+    float distPerRot = -1;
+    if (gearTeeth != -1 and chainPitch != -1){
+        float distPerRot = gearTeeth*chainPitch; 
+        leftAxis.changePitch(distPerRot);
+        rightAxis.changePitch(distPerRot);
+        zAxis.changePitch(zDistPerRot);
+    }
     
-    leftAxis.changeEncoderResolution(encoderSteps);
-    rightAxis.changeEncoderResolution(encoderSteps);
-    zAxis.changeEncoderResolution(zEncoderSteps);
+    //update the number of encoder steps if new values have been recieved
+    if (encoderSteps != -1){
+        leftAxis.changeEncoderResolution(encoderSteps);
+        rightAxis.changeEncoderResolution(encoderSteps);
+    }
+    if (zEncoderSteps != -1){
+        zAxis.changeEncoderResolution(zEncoderSteps);
+    }
     
-    //Change the machine dimensions in the kinematics 
-    kinematics.l            = sledWidth;
-    kinematics.s            = sledHeight;
-    kinematics.h3           = sledCG;
-    kinematics.R            = distPerRot / (2.0*3.14159);
-    kinematics.D            = distBetweenMotors;
-    kinematics.motorOffsetY = motorOffsetY;
-    kinematics.machineWidth = bedWidth;
-    kinematics.machineHeight= bedHeight;
+    //Change the machine dimensions in the kinematics if new values have been received
+    if (sledWidth != -1){
+        kinematics.l            = sledWidth;
+    }
+    if (sledHeight != -1){
+        kinematics.s            = sledHeight;
+    }
+    if (sledCG != -1){
+        kinematics.h3           = sledCG;
+    }
+    if (distPerRot != -1){
+        kinematics.R            = distPerRot / (2.0*3.14159);
+    }
+    if (distBetweenMotors != -1){
+        kinematics.D            = distBetweenMotors;
+    }
+    if (motorOffsetY != -1){
+        kinematics.motorOffsetY = motorOffsetY;
+    }
+    if (bedWidth != -1){
+        kinematics.machineWidth = bedWidth;
+    }
+    if (bedHeight != -1){
+        kinematics.machineHeight= bedHeight;
+    }
+    
+    //propagate the new values
     kinematics.recomputeGeometry();
     
     kinematics.forward(leftAxis.read(), rightAxis.read(), &xTarget, &yTarget);
@@ -1086,7 +1111,7 @@ void  executeGcodeLine(const String& gcodeLine){
         Serial.print(rightAxis.read());
         Serial.println(F("mm"));
         
-        kinematics.forward(leftAxis.read(), rightAxis.read(), &xTarget, &yTarget);
+        //kinematics.forward(leftAxis.read(), rightAxis.read(), &xTarget, &yTarget);
         
         Serial.println(F("Message: The machine chains have been manually re-calibrated."));
         

--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -964,6 +964,21 @@ void  updateSettings(const String& readString){
     float zDistPerRot        = extractGcodeValue(readString, 'N', ZDISTPERROT);
     int zEncoderSteps        = extractGcodeValue(readString, 'P', ZENCODERSTEPS);
     
+    float KpPos              = extractGcodeValue(readString, 'S', 0);
+    float KiPos              = extractGcodeValue(readString, 'T', 0);
+    float KdPos              = extractGcodeValue(readString, 'U', 0);
+    float KpV                = extractGcodeValue(readString, 'V', 0);
+    float KiV                = extractGcodeValue(readString, 'W', 0);
+    float KdV                = extractGcodeValue(readString, 'X', 0);
+    
+    Serial.println("KValues");
+    Serial.println(KpPos);
+    Serial.println(KiPos);
+    Serial.println(KdPos);
+    Serial.println(KpV);
+    Serial.println(KiV);
+    Serial.println(KdV);
+    
     //Change the motor properties in cnc_funtions
     float distPerRot = gearTeeth*chainPitch; 
     leftAxis.changePitch(distPerRot);

--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -951,6 +951,7 @@ void  updateSettings(const String& readString){
 
     float bedWidth           = extractGcodeValue(readString, 'A', -1);
     float bedHeight          = extractGcodeValue(readString, 'C', -1);
+    float distBetweenMotors  = extractGcodeValue(readString, 'Q', -1);
     float motorOffsetY       = extractGcodeValue(readString, 'E', -1);
     float sledWidth          = extractGcodeValue(readString, 'F', -1);
     float sledHeight         = extractGcodeValue(readString, 'R', -1);
@@ -986,13 +987,16 @@ void  updateSettings(const String& readString){
         zAxis.changePitch(zDistPerRot);
     }
     
-    //update the number of encoder steps if new values have been recieved
+    //update the number of encoder steps if new values have been received
     if (encoderSteps != -1){
         leftAxis.changeEncoderResolution(encoderSteps);
         rightAxis.changeEncoderResolution(encoderSteps);
+        leftAxis.loadPositionFromMemory();
+        rightAxis.loadPositionFromMemory();
     }
     if (zEncoderSteps != -1){
         zAxis.changeEncoderResolution(zEncoderSteps);
+        zAxis.loadPositionFromMemory();
     }
     
     //Change the machine dimensions in the kinematics if new values have been received

--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -924,7 +924,7 @@ void  calibrateChainLengths(){
     Serial.print(rightAxis.read());
     Serial.println(F("mm"));
     
-    //kinematics.forward(leftAxis.read(), rightAxis.read(), &xTarget, &yTarget);
+    kinematics.forward(leftAxis.read(), rightAxis.read(), &xTarget, &yTarget);
     
     
     leftAxis.setPIDAggressiveness(1);
@@ -1115,7 +1115,7 @@ void  executeGcodeLine(const String& gcodeLine){
         Serial.print(rightAxis.read());
         Serial.println(F("mm"));
         
-        //kinematics.forward(leftAxis.read(), rightAxis.read(), &xTarget, &yTarget);
+        kinematics.forward(leftAxis.read(), rightAxis.read(), &xTarget, &yTarget);
         
         Serial.println(F("Message: The machine chains have been manually re-calibrated."));
         

--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -971,13 +971,12 @@ void  updateSettings(const String& readString){
     float KiV                = extractGcodeValue(readString, 'W', 0);
     float KdV                = extractGcodeValue(readString, 'X', 0);
     
-    Serial.println("KValues");
-    Serial.println(KpPos);
-    Serial.println(KiPos);
-    Serial.println(KdPos);
-    Serial.println(KpV);
-    Serial.println(KiV);
-    Serial.println(KdV);
+    //Write the PID values to the axies if new ones have been received
+    if (KpPos != 0 or KiPos != 0 or KdPos != 0){
+        leftAxis.setPIDValues(KpPos, KiPos, KdPos);
+        rightAxis.setPIDValues(KpPos, KiPos, KdPos);
+        zAxis.setPIDValues(KpPos, KiPos, KdPos);
+    }
     
     //Change the motor properties in cnc_funtions
     float distPerRot = gearTeeth*chainPitch; 

--- a/cnc_ctrl_v1/Kinematics.cpp
+++ b/cnc_ctrl_v1/Kinematics.cpp
@@ -160,7 +160,11 @@ void  Kinematics::inverse(float xTarget,float yTarget, float* aChainLength, floa
 }
 
 void  Kinematics::forward(const float& chainALength, const float& chainBLength, float* xPos, float* yPos){
-
+    
+    Serial.println("Called with: ");
+    Serial.println(chainALength);
+    Serial.println(chainBLength);
+    
     float xGuess = 0;
     float yGuess = 0;
 

--- a/cnc_ctrl_v1/Kinematics.cpp
+++ b/cnc_ctrl_v1/Kinematics.cpp
@@ -161,10 +161,6 @@ void  Kinematics::inverse(float xTarget,float yTarget, float* aChainLength, floa
 
 void  Kinematics::forward(const float& chainALength, const float& chainBLength, float* xPos, float* yPos){
     
-    Serial.println("Called with: ");
-    Serial.println(chainALength);
-    Serial.println(chainBLength);
-    
     float xGuess = 0;
     float yGuess = 0;
 

--- a/cnc_ctrl_v1/MotorGearboxEncoder.cpp
+++ b/cnc_ctrl_v1/MotorGearboxEncoder.cpp
@@ -123,6 +123,21 @@ void  MotorGearboxEncoder::computePID(){
     motor.write(_pidOutput);
 }
 
+void  MotorGearboxEncoder::setPIDValues(float KpV, float KiV, float KdV){
+    /*
+    
+    Set PID tuning values
+    
+    */
+    
+    _Kp = KpV;
+    _Ki = KiV;
+    _Kd = KdV;
+    
+    _posPIDController.SetTunings(_Kp, _Ki, _Kd);
+    _negPIDController.SetTunings(_Kp, _Ki, _Kd);
+}
+
 void MotorGearboxEncoder::setPIDAggressiveness(float aggressiveness){
     /*
     

--- a/cnc_ctrl_v1/MotorGearboxEncoder.h
+++ b/cnc_ctrl_v1/MotorGearboxEncoder.h
@@ -34,6 +34,7 @@
             void       setName(const String& newName);
             void       initializePID();
             void       setPIDAggressiveness(float aggressiveness);
+            void       setPIDValues(float KpV, float KiV, float KdV);
         private:
             double     _targetSpeed;
             double     _currentSpeed;
@@ -44,7 +45,7 @@
             double     _pidOutput;
             PID        _posPIDController;
             PID        _negPIDController;
-            double     _Kp=20, _Ki=1, _Kd=0;
+            double     _Kp=0, _Ki=0, _Kd=0;
             int        _oldValue1;
             int        _oldValue2;
             int        _oldValue3;

--- a/cnc_ctrl_v1/MotorGearboxEncoder.h
+++ b/cnc_ctrl_v1/MotorGearboxEncoder.h
@@ -44,7 +44,7 @@
             double     _pidOutput;
             PID        _posPIDController;
             PID        _negPIDController;
-            double     _Kp=20, _Ki=1, _Kd=0;
+            double     _Kp=0, _Ki=0, _Kd=0;
             int        _oldValue1;
             int        _oldValue2;
             int        _oldValue3;

--- a/cnc_ctrl_v1/MotorGearboxEncoder.h
+++ b/cnc_ctrl_v1/MotorGearboxEncoder.h
@@ -44,7 +44,7 @@
             double     _pidOutput;
             PID        _posPIDController;
             PID        _negPIDController;
-            double     _Kp=0, _Ki=0, _Kd=0;
+            double     _Kp=20, _Ki=1, _Kd=0;
             int        _oldValue1;
             int        _oldValue2;
             int        _oldValue3;

--- a/cnc_ctrl_v1/PID_v1.cpp
+++ b/cnc_ctrl_v1/PID_v1.cpp
@@ -59,7 +59,7 @@ bool PID::Compute()
     //with a consistent sample period
 
     /*Compute all the working error variables*/
-    double input = *myInput;
+    double input = *myInput; 
     double error = *mySetpoint - input;
     ITerm+= (ki * error);
 
@@ -208,7 +208,7 @@ void PID::FlipIntegrator(){
  * functions query the internal state of the PID.  they're here for display
  * purposes.  this are the functions the PID Front-end uses for example
  ******************************************************************************/
-double PID::GetKp(){ return  dispKp; }
+double PID::GetKp(){ return  dispKp;}
 double PID::GetKi(){ return  dispKi;}
 double PID::GetKd(){ return  dispKd;}
 int PID::GetMode(){ return  inAuto ? AUTOMATIC : MANUAL;}

--- a/cnc_ctrl_v1/cnc_ctrl_v1.ino
+++ b/cnc_ctrl_v1/cnc_ctrl_v1.ino
@@ -21,8 +21,6 @@ void setup(){
     readyCommandString.reserve(128);           //Allocate memory so that this string doesn't fragment the heap as it grows and shrinks
     gcodeLine.reserve(128);
     
-    //kinematics.forward(leftAxis.read(), rightAxis.read(), &xTarget, &yTarget);
-    
     if(pcbRevisionIndicator == 0){
     Serial.println(F("PCB v1.1 Detected"));
     } 

--- a/cnc_ctrl_v1/cnc_ctrl_v1.ino
+++ b/cnc_ctrl_v1/cnc_ctrl_v1.ino
@@ -21,7 +21,7 @@ void setup(){
     readyCommandString.reserve(128);           //Allocate memory so that this string doesn't fragment the heap as it grows and shrinks
     gcodeLine.reserve(128);
     
-    kinematics.forward(leftAxis.read(), rightAxis.read(), &xTarget, &yTarget);
+    //kinematics.forward(leftAxis.read(), rightAxis.read(), &xTarget, &yTarget);
     
     if(pcbRevisionIndicator == 0){
     Serial.println(F("PCB v1.1 Detected"));


### PR DESCRIPTION
Load PID values from Ground Control and revamp the way that settings are loaded in general to make sure that values are only defined in one place