### PR TITLE
Make switching to new kinematics possible

### DIFF
--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -961,6 +961,8 @@ void  updateSettings(const String& readString){
     float KpV                = extractGcodeValue(readString, 'V', -1);
     float KiV                = extractGcodeValue(readString, 'W', -1);
     float KdV                = extractGcodeValue(readString, 'X', -1);
+    float kinematicsType     = extractGcodeValue(readString, 'Y', -1);
+    float rotationDiskRadius = extractGcodeValue(readString, 'Z', -1);
     
     //Write the PID values to the axis if new ones have been received
     if (KpPos != -1){
@@ -1014,6 +1016,12 @@ void  updateSettings(const String& readString){
     }
     if (bedHeight != -1){
         kinematics.machineHeight= bedHeight;
+    }
+    if (kinematicsType != -1){
+        kinematics.kinematicsType = kinematicsType;
+    }
+    if (rotationDiskRadius != -1){
+        kinematics.rotationDiskRadius = rotationDiskRadius;
     }
     
     //propagate the new values

--- a/cnc_ctrl_v1/Kinematics.cpp
+++ b/cnc_ctrl_v1/Kinematics.cpp
@@ -160,6 +160,17 @@ void  Kinematics::inverse(float xTarget,float yTarget, float* aChainLength, floa
 }
 
 void  Kinematics::forward(const float& chainALength, const float& chainBLength, float* xPos, float* yPos){
+    /*
+    
+    This function works as a switch to call either the quadrilateralForward kinematic function 
+    or the triangularForward kinematic function
+    
+    */
+    
+    quadrilateralForward(chainALength, chainBLength, xPos, yPos);
+}
+
+void  Kinematics::quadrilateralForward(const float& chainALength, const float& chainBLength, float* xPos, float* yPos){
     
     float xGuess = 0;
     float yGuess = 0;

--- a/cnc_ctrl_v1/Kinematics.cpp
+++ b/cnc_ctrl_v1/Kinematics.cpp
@@ -56,7 +56,12 @@ void  Kinematics::inverse(float xTarget,float yTarget, float* aChainLength, floa
     
     */
     
-    quadrilateralInverse(xTarget, yTarget, aChainLength, bChainLength);
+    if(kinematicsType == 1){
+        quadrilateralInverse(xTarget, yTarget, aChainLength, bChainLength);
+    }
+    else{
+        triangularInverse(xTarget, yTarget, aChainLength, bChainLength);
+    }
     
 }
 

--- a/cnc_ctrl_v1/Kinematics.cpp
+++ b/cnc_ctrl_v1/Kinematics.cpp
@@ -49,6 +49,17 @@ void Kinematics::recomputeGeometry(){
 }
 
 void  Kinematics::inverse(float xTarget,float yTarget, float* aChainLength, float* bChainLength){
+    /*
+    
+    This function works as a switch to call either the quadrilateralInverse kinematic function 
+    or the triangularInverse kinematic function
+    
+    */
+    
+    quadrilateralInverse(xTarget, yTarget, aChainLength, bChainLength);
+    
+}
+void  Kinematics::quadrilateralInverse(float xTarget,float yTarget, float* aChainLength, float* bChainLength){
 
     //Confirm that the coordinates are on the wood
     _verifyValidTarget(&xTarget, &yTarget);
@@ -160,17 +171,6 @@ void  Kinematics::inverse(float xTarget,float yTarget, float* aChainLength, floa
 }
 
 void  Kinematics::forward(const float& chainALength, const float& chainBLength, float* xPos, float* yPos){
-    /*
-    
-    This function works as a switch to call either the quadrilateralForward kinematic function 
-    or the triangularForward kinematic function
-    
-    */
-    
-    quadrilateralForward(chainALength, chainBLength, xPos, yPos);
-}
-
-void  Kinematics::quadrilateralForward(const float& chainALength, const float& chainBLength, float* xPos, float* yPos){
     
     float xGuess = 0;
     float yGuess = 0;

--- a/cnc_ctrl_v1/Kinematics.cpp
+++ b/cnc_ctrl_v1/Kinematics.cpp
@@ -59,6 +59,7 @@ void  Kinematics::inverse(float xTarget,float yTarget, float* aChainLength, floa
     quadrilateralInverse(xTarget, yTarget, aChainLength, bChainLength);
     
 }
+
 void  Kinematics::quadrilateralInverse(float xTarget,float yTarget, float* aChainLength, float* bChainLength){
 
     //Confirm that the coordinates are on the wood
@@ -168,6 +169,29 @@ void  Kinematics::quadrilateralInverse(float xTarget,float yTarget, float* aChai
     *aChainLength = Chain1;
     *bChainLength = Chain2;
 
+}
+
+void  Kinematics::triangularInverse(float xTarget,float yTarget, float* aChainLength, float* bChainLength){
+    /*
+    
+    The inverse kinematics (relating an xy coordinate pair to the required chain lengths to hit that point)
+    function for a triangular set up where the chains meet at a point, or are arranged so that they simulate 
+    meeting at a point.
+    
+    */
+    
+    //Confirm that the coordinates are on the wood
+    _verifyValidTarget(&xTarget, &yTarget);
+    
+    float Chain1 = sqrt(pow((-1*_xCordOfMotor - xTarget),2)+pow((_yCordOfMotor - yTarget),2));
+    float Chain2 = sqrt(pow((_xCordOfMotor - xTarget),2)+pow((_yCordOfMotor - yTarget),2));
+    
+    //Subtract of the virtual length which is added to the chain by the rotation mechanism
+    Chain1 = Chain1 - rotationDiskRadius;
+    Chain2 = Chain2 - rotationDiskRadius;
+    
+    *aChainLength = Chain1;
+    *bChainLength = Chain2;
 }
 
 void  Kinematics::forward(const float& chainALength, const float& chainBLength, float* xPos, float* yPos){

--- a/cnc_ctrl_v1/Kinematics.h
+++ b/cnc_ctrl_v1/Kinematics.h
@@ -38,7 +38,8 @@
             float h3            = 79.0;                                //distance from bit to sled center of mass
             float D             = 2978.4;                              //distance between sprocket centers
             float R             = 10.2;                                //sprocket radius
-            float rotationDiskRadius = 210/2;                          //distance from the bit to the attachment point
+            float rotationDiskRadius = 0;                              //distance from the bit to the attachment point
+            int kinematicsType  = 1;                                   //Which version of the kinematics to use. 1 is quadrilateral, 2 is triangular
 
 
             //machine dimensions

--- a/cnc_ctrl_v1/Kinematics.h
+++ b/cnc_ctrl_v1/Kinematics.h
@@ -28,6 +28,7 @@
             Kinematics();
             void  inverse   (float xTarget,float yTarget, float* aChainLength, float* bChainLength);
             void  quadrilateralInverse   (float xTarget,float yTarget, float* aChainLength, float* bChainLength);
+            void  triangularInverse   (float xTarget,float yTarget, float* aChainLength, float* bChainLength);
             void  recomputeGeometry();
             void  forward(const float& chainALength, const float& chainBLength, float* xPos, float* yPos);
             //geometry
@@ -37,6 +38,7 @@
             float h3            = 79.0;                                //distance from bit to sled center of mass
             float D             = 2978.4;                              //distance between sprocket centers
             float R             = 10.2;                                //sprocket radius
+            float rotationDiskRadius = 210/2;                          //distance from the bit to the attachment point
 
 
             //machine dimensions
@@ -53,8 +55,10 @@
             void  _MyTrig();
             void _verifyValidTarget(float* xTarget,float* yTarget);
             //target router bit coordinates.
-            float x = 2708.4;
-            float y = 270;
+            float x = 0;
+            float y = 0;
+            float _xCordOfMotor = D/2;
+            float _yCordOfMotor = halfHeight + motorOffsetY;
 
 
 

--- a/cnc_ctrl_v1/Kinematics.h
+++ b/cnc_ctrl_v1/Kinematics.h
@@ -27,9 +27,9 @@
         public:
             Kinematics();
             void  inverse   (float xTarget,float yTarget, float* aChainLength, float* bChainLength);
+            void  quadrilateralInverse   (float xTarget,float yTarget, float* aChainLength, float* bChainLength);
             void  recomputeGeometry();
             void  forward(const float& chainALength, const float& chainBLength, float* xPos, float* yPos);
-            void  quadrilateralForward(const float& chainALength, const float& chainBLength, float* xPos, float* yPos);
             //geometry
             float l             = 310.0;                               //horizontal distance between sled attach points
             float s             = 139.0;                               //vertical distance between sled attach points and bit

--- a/cnc_ctrl_v1/Kinematics.h
+++ b/cnc_ctrl_v1/Kinematics.h
@@ -29,6 +29,7 @@
             void  inverse   (float xTarget,float yTarget, float* aChainLength, float* bChainLength);
             void  recomputeGeometry();
             void  forward(const float& chainALength, const float& chainBLength, float* xPos, float* yPos);
+            void  quadrilateralForward(const float& chainALength, const float& chainBLength, float* xPos, float* yPos);
             //geometry
             float l             = 310.0;                               //horizontal distance between sled attach points
             float s             = 139.0;                               //vertical distance between sled attach points and bit

--- a/cnc_ctrl_v1/cnc_ctrl_v1.ino
+++ b/cnc_ctrl_v1/cnc_ctrl_v1.ino
@@ -22,7 +22,7 @@ void setup(){
     gcodeLine.reserve(128);
     
     if(pcbRevisionIndicator == 0){
-    Serial.println(F("PCB v1.1 Detected"));
+        Serial.println(F("PCB v1.1 Detected"));
     } 
     if(pcbRevisionIndicator == 1){
         Serial.println(F("Beta PCB v1.0 Detected"));


### PR DESCRIPTION
Enables the settings option which switches from quadrilateral kinematics to triangular kinematics to support systems where the chains meet at a point or simulate meeting at a point