### PR TITLE
fix manual z-axis

### DIFF
--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -947,7 +947,9 @@ void  updateSettings(const String& readString){
     float sledWidth          = extractGcodeValue(readString, 'F', -1);
     float sledHeight         = extractGcodeValue(readString, 'R', -1);
     float sledCG             = extractGcodeValue(readString, 'H', -1);
-    zAxisAttached            = extractGcodeValue(readString, 'I', -1);
+    if (extractGcodeValue(readString, 'I', -1) != -1){
+        zAxisAttached            = extractGcodeValue(readString, 'I', -1);
+    }
     int encoderSteps         = extractGcodeValue(readString, 'J', -1);
     float gearTeeth          = extractGcodeValue(readString, 'K', -1);
     float chainPitch         = extractGcodeValue(readString, 'M', -1);


### PR DESCRIPTION
Manual z-axis settings were broken by the changes to the way settings are loaded in 0.83