### PR TITLE
changed _pid variables to volatile

### DIFF
--- a/cnc_ctrl_v1/Axis.h
+++ b/cnc_ctrl_v1/Axis.h
@@ -61,7 +61,9 @@
             int        _currentAngle;
             int        _previousAngle;
             double     _timeLastMoved;
-            double     _pidSetpoint, _pidInput, _pidOutput;
+            volatile double _pidSetpoint;
+            volatile double _pidInput; 
+            volatile double _pidOutput;
             double     _Kp=0, _Ki = 0, _Kd=0;
             PID        _pidController;
             int        _eepromAdr;


### PR DESCRIPTION
_pidSetpoint _pidInput and _pidOutput should be volatile since they are modified and accessed by  multiple execution contexts (ISR and mainline code) to ensure that the value is retrieved from RAM and not a register