### PR TITLE
Split b03 into multiple commands

### DIFF
--- a/cnc_ctrl_v1/Axis.cpp
+++ b/cnc_ctrl_v1/Axis.cpp
@@ -55,9 +55,6 @@ void   Axis::loadPositionFromMemory(){
             set(_readFloat(_eepromAdr + SIZEOFFLOAT));
         }
         
-        Serial.println("Load: ");
-        Serial.println(_axisName);
-        Serial.println(_readFloat(_eepromAdr + SIZEOFFLOAT));
 }
 
 void   Axis::initializePID(){
@@ -74,10 +71,6 @@ void    Axis::write(const float& targetPosition){
 
 float  Axis::read(){
     //returns the true axis position
-    
-    /*Serial.println(_encoderSteps);
-    Serial.println(_mmPerRotation);
-    Serial.println(motorGearboxEncoder.encoder.read());*/
     
     return (motorGearboxEncoder.encoder.read()/_encoderSteps)*_mmPerRotation;
     
@@ -169,8 +162,6 @@ void   Axis::changePitch(const float& newPitch){
     Reassign the distance moved per-rotation for the axis.
     */
     _mmPerRotation = newPitch;
-    Serial.println("Set Pitch");
-    Serial.println(_mmPerRotation);
 }
 
 void   Axis::changeEncoderResolution(const int& newResolution){
@@ -178,8 +169,6 @@ void   Axis::changeEncoderResolution(const int& newResolution){
     Reassign the encoder resolution for the axis.
     */
     _encoderSteps = newResolution;
-    Serial.println("Set Resolution");
-    Serial.println(_encoderSteps);
     
 }
 
@@ -188,9 +177,6 @@ int    Axis::detach(){
     if (motorGearboxEncoder.motor.attached()){
         _writeFloat (_eepromAdr+SIZEOFFLOAT, read());      //Store the axis position
         EEPROM.write(_eepromAdr, EEPROMVALIDDATA);
-        Serial.println("Writing:");
-        Serial.println(_axisName);
-        Serial.println(read());
         
     }
     

--- a/cnc_ctrl_v1/Axis.cpp
+++ b/cnc_ctrl_v1/Axis.cpp
@@ -54,6 +54,10 @@ void   Axis::loadPositionFromMemory(){
         if (EEPROM.read(_eepromAdr) == EEPROMVALIDDATA){
             set(_readFloat(_eepromAdr + SIZEOFFLOAT));
         }
+        
+        Serial.println("Load: ");
+        Serial.println(_axisName);
+        Serial.println(_readFloat(_eepromAdr + SIZEOFFLOAT));
 }
 
 void   Axis::initializePID(){
@@ -71,7 +75,12 @@ void    Axis::write(const float& targetPosition){
 float  Axis::read(){
     //returns the true axis position
     
+    /*Serial.println(_encoderSteps);
+    Serial.println(_mmPerRotation);
+    Serial.println(motorGearboxEncoder.encoder.read());*/
+    
     return (motorGearboxEncoder.encoder.read()/_encoderSteps)*_mmPerRotation;
+    
 }
 
 float  Axis::target(){
@@ -160,6 +169,8 @@ void   Axis::changePitch(const float& newPitch){
     Reassign the distance moved per-rotation for the axis.
     */
     _mmPerRotation = newPitch;
+    Serial.println("Set Pitch");
+    Serial.println(_mmPerRotation);
 }
 
 void   Axis::changeEncoderResolution(const int& newResolution){
@@ -167,6 +178,8 @@ void   Axis::changeEncoderResolution(const int& newResolution){
     Reassign the encoder resolution for the axis.
     */
     _encoderSteps = newResolution;
+    Serial.println("Set Resolution");
+    Serial.println(_encoderSteps);
     
 }
 
@@ -175,6 +188,9 @@ int    Axis::detach(){
     if (motorGearboxEncoder.motor.attached()){
         _writeFloat (_eepromAdr+SIZEOFFLOAT, read());      //Store the axis position
         EEPROM.write(_eepromAdr, EEPROMVALIDDATA);
+        Serial.println("Writing:");
+        Serial.println(_axisName);
+        Serial.println(read());
         
     }
     

--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -913,7 +913,7 @@ void  calibrateChainLengths(){
     Serial.print(rightAxis.read());
     Serial.println(F("mm"));
     
-    //kinematics.forward(leftAxis.read(), rightAxis.read(), &xTarget, &yTarget);
+    kinematics.forward(leftAxis.read(), rightAxis.read(), &xTarget, &yTarget);
     
     
     leftAxis.setPIDAggressiveness(1);
@@ -1129,7 +1129,7 @@ void  executeGcodeLine(const String& gcodeLine){
         Serial.print(rightAxis.read());
         Serial.println(F("mm"));
         
-        //kinematics.forward(leftAxis.read(), rightAxis.read(), &xTarget, &yTarget);
+        kinematics.forward(leftAxis.read(), rightAxis.read(), &xTarget, &yTarget);
         
         Serial.println(F("Message: The machine chains have been manually re-calibrated."));
         

--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -986,12 +986,9 @@ void  updateKinematicsSettings(const String& readString){
     //propagate the new values
     kinematics.recomputeGeometry();
     
-    Serial.println("leftAxis.read:");
-    Serial.println(leftAxis.read());
-    
     kinematics.forward(leftAxis.read(), rightAxis.read(), &xTarget, &yTarget);
     
-    Serial.println(F("Kinematics Settings Updated"));
+    Serial.println(F("Kinematics Settings Loaded"));
 }
 
 void updateMotorSettings(const String& readString){

--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -145,8 +145,6 @@ String gcodeLine;                         //The next individual line of gcode (f
 
 int   lastCommand           =  0;         //Stores the value of the last command run eg: G01 -> 1
 
-//These are used in place of a forward kinematic function at the beginning of each move. They should be replaced
-//by a call to the forward kinematic function when it is available.
 float xTarget = 0;
 float yTarget = 0;
 
@@ -915,7 +913,7 @@ void  calibrateChainLengths(){
     Serial.print(rightAxis.read());
     Serial.println(F("mm"));
     
-    kinematics.forward(leftAxis.read(), rightAxis.read(), &xTarget, &yTarget);
+    //kinematics.forward(leftAxis.read(), rightAxis.read(), &xTarget, &yTarget);
     
     
     leftAxis.setPIDAggressiveness(1);
@@ -987,6 +985,9 @@ void  updateKinematicsSettings(const String& readString){
     
     //propagate the new values
     kinematics.recomputeGeometry();
+    
+    Serial.println("leftAxis.read:");
+    Serial.println(leftAxis.read());
     
     kinematics.forward(leftAxis.read(), rightAxis.read(), &xTarget, &yTarget);
     
@@ -1128,7 +1129,7 @@ void  executeGcodeLine(const String& gcodeLine){
         Serial.print(rightAxis.read());
         Serial.println(F("mm"));
         
-        kinematics.forward(leftAxis.read(), rightAxis.read(), &xTarget, &yTarget);
+        //kinematics.forward(leftAxis.read(), rightAxis.read(), &xTarget, &yTarget);
         
         Serial.println(F("Message: The machine chains have been manually re-calibrated."));
         

--- a/cnc_ctrl_v1/Kinematics.cpp
+++ b/cnc_ctrl_v1/Kinematics.cpp
@@ -201,6 +201,10 @@ void  Kinematics::triangularInverse(float xTarget,float yTarget, float* aChainLe
 
 void  Kinematics::forward(const float& chainALength, const float& chainBLength, float* xPos, float* yPos){
     
+    Serial.println("Kinematics Begin With:");
+    Serial.println(chainALength);
+    Serial.println(chainBLength);
+    
     float xGuess = 0;
     float yGuess = 0;
 
@@ -208,7 +212,7 @@ void  Kinematics::forward(const float& chainALength, const float& chainBLength, 
     float guessLengthB;
 
     int guessCount = 0;
-    int maxNumberOfGuesses = 200;
+    int maxNumberOfGuesses = 100;
 
     while(1){
 
@@ -223,6 +227,16 @@ void  Kinematics::forward(const float& chainALength, const float& chainBLength, 
         //adjust the guess based on the result
         xGuess = xGuess + .1*aChainError - .1*bChainError;
         yGuess = yGuess - .1*aChainError - .1*bChainError;
+        
+        /*Serial.println("~~*");
+        Serial.println(xGuess);
+        Serial.println(yGuess);
+        Serial.println(guessLengthA);
+        Serial.println(guessLengthB);
+        Serial.println(chainALength);
+        Serial.println(chainBLength);
+        Serial.println(aChainError);
+        Serial.println(bChainError);*/
 
         guessCount++;
 
@@ -238,14 +252,33 @@ void  Kinematics::forward(const float& chainALength, const float& chainBLength, 
         //if we've converged on the point...or it's time to give up, exit the loop
         if((abs(aChainError) < .1 && abs(bChainError) < .1) or guessCount > maxNumberOfGuesses){
             if(guessCount > maxNumberOfGuesses){
-                Serial.println(F("Message: Unable to find valid machine position. Please calibrate chain lengths."));
-                Serial.println(F("Lengths: "));
-                Serial.println(chainALength);
-                Serial.println(chainBLength);
+                Serial.print(F("Message: Unable to find valid machine position for chain lengths "));
+                Serial.print(chainALength);
+                Serial.print(", ");
+                Serial.print(chainBLength);
+                Serial.println(F(" . Please calibrate chain lengths."));
+                /*inverse(xGuess, yGuess, &guessLengthA, &guessLengthB);
+                Serial.println("**");
+                Serial.println(xGuess);
+                Serial.println(yGuess);
+                Serial.println("--");
+                Serial.println(h);
+                Serial.println(s);
+                Serial.println(D);
+                Serial.println(R);
+                Serial.println(kinematicsType);
+                Serial.println(machineHeight);
+                Serial.println(machineWidth);
+                Serial.println(motorOffsetY);
+                Serial.println(halfWidth);
+                Serial.println(halfHeight);*/
                 *xPos = 0;
                 *yPos = 0;
             }
             else{
+                Serial.println("position loaded at:");
+                Serial.println(xGuess);
+                Serial.println(yGuess);
                 *xPos = xGuess;
                 *yPos = yGuess;
             }

--- a/cnc_ctrl_v1/Kinematics.cpp
+++ b/cnc_ctrl_v1/Kinematics.cpp
@@ -201,10 +201,6 @@ void  Kinematics::triangularInverse(float xTarget,float yTarget, float* aChainLe
 
 void  Kinematics::forward(const float& chainALength, const float& chainBLength, float* xPos, float* yPos){
     
-    Serial.println("Kinematics Begin With:");
-    Serial.println(chainALength);
-    Serial.println(chainBLength);
-    
     float xGuess = 0;
     float yGuess = 0;
 
@@ -212,7 +208,7 @@ void  Kinematics::forward(const float& chainALength, const float& chainBLength, 
     float guessLengthB;
 
     int guessCount = 0;
-    int maxNumberOfGuesses = 100;
+    int maxNumberOfGuesses = 200;
 
     while(1){
 
@@ -228,16 +224,6 @@ void  Kinematics::forward(const float& chainALength, const float& chainBLength, 
         xGuess = xGuess + .1*aChainError - .1*bChainError;
         yGuess = yGuess - .1*aChainError - .1*bChainError;
         
-        /*Serial.println("~~*");
-        Serial.println(xGuess);
-        Serial.println(yGuess);
-        Serial.println(guessLengthA);
-        Serial.println(guessLengthB);
-        Serial.println(chainALength);
-        Serial.println(chainBLength);
-        Serial.println(aChainError);
-        Serial.println(bChainError);*/
-
         guessCount++;
 
         //Prevent the connection from timing out
@@ -257,21 +243,6 @@ void  Kinematics::forward(const float& chainALength, const float& chainBLength, 
                 Serial.print(", ");
                 Serial.print(chainBLength);
                 Serial.println(F(" . Please calibrate chain lengths."));
-                /*inverse(xGuess, yGuess, &guessLengthA, &guessLengthB);
-                Serial.println("**");
-                Serial.println(xGuess);
-                Serial.println(yGuess);
-                Serial.println("--");
-                Serial.println(h);
-                Serial.println(s);
-                Serial.println(D);
-                Serial.println(R);
-                Serial.println(kinematicsType);
-                Serial.println(machineHeight);
-                Serial.println(machineWidth);
-                Serial.println(motorOffsetY);
-                Serial.println(halfWidth);
-                Serial.println(halfHeight);*/
                 *xPos = 0;
                 *yPos = 0;
             }


### PR DESCRIPTION
We were seeing issues with the kinematics being unable to load the machine's position.

The issue was that if the machine tried to load it's position from memory before it had been told the specs for the motors it would load an incorrect position, then save incorrect chain lengths to memory. The next time the position was loaded from memory it would be wrong and the machine would try to compute a new position from the incorrect chain lengths and fail