### PR TITLE
Recompute cordinates of motors if machine geometry changes

### DIFF
--- a/cnc_ctrl_v1/Kinematics.cpp
+++ b/cnc_ctrl_v1/Kinematics.cpp
@@ -45,6 +45,9 @@ void Kinematics::recomputeGeometry(){
     Theta = atan(2*s/l);
     Psi1 = Theta - Phi;
     Psi2 = Theta + Phi;
+    
+    _xCordOfMotor = D/2;
+    _yCordOfMotor = halfHeight + motorOffsetY;
 
 }
 


### PR DESCRIPTION
Recompute the xy cordinates of the motors when the machine's geometry is updated.

Fixes an issue with triangular kinematics