### PR TITLE
Require Machine Settings Before Unsafe Commands

### DIFF
--- a/cnc_ctrl_v1/Axis.cpp
+++ b/cnc_ctrl_v1/Axis.cpp
@@ -52,7 +52,9 @@ void   Axis::loadPositionFromMemory(){
         
         //If a valid position has been stored
         if (EEPROM.read(_eepromAdr) == EEPROMVALIDDATA){
-            set(_readFloat(_eepromAdr + SIZEOFFLOAT));
+            float f = 0.00f;
+            f = EEPROM.get(_eepromAdr + SIZEOFFLOAT, f );
+            set(f);
         }
         
 }
@@ -175,9 +177,9 @@ void   Axis::changeEncoderResolution(const int& newResolution){
 int    Axis::detach(){
     
     if (motorGearboxEncoder.motor.attached()){
-        _writeFloat (_eepromAdr+SIZEOFFLOAT, read());      //Store the axis position
-        EEPROM.write(_eepromAdr, EEPROMVALIDDATA);
-        
+        float f = read();  //Store the axis position
+        EEPROM.put(_eepromAdr + SIZEOFFLOAT, f);
+        EEPROM.update(_eepromAdr, EEPROMVALIDDATA);
     }
     
     motorGearboxEncoder.motor.detach();
@@ -219,36 +221,6 @@ void   Axis::endMove(const float& finalTarget){
     
 }
 
-float  Axis::_readFloat(const unsigned int& addr){
-
-//readFloat and writeFloat functions courtesy of http://www.alexenglish.info/2014/05/saving-floats-longs-ints-eeprom-arduino-using-unions/
-
-
-    union{
-        byte b[4];
-        float f;
-    } data;
-    for(int i = 0; i < 4; i++)
-    {
-        data.b[i] = EEPROM.read(addr+i);
-    }
-    return data.f;
-}
-
-void   Axis::_writeFloat(const unsigned int& addr, const float& x){
-    
-    //Writes a floating point number into the eeprom memory by splitting it into four one byte chunks and saving them
-    
-    union{
-        byte b[4];
-        float f;
-    } data;
-    data.f = x;
-    for(int i = 0; i < 4; i++){
-        EEPROM.write(addr+i, data.b[i]);
-    }
-}
-
 void   Axis::wipeEEPROM(){
     /*
     
@@ -258,7 +230,7 @@ void   Axis::wipeEEPROM(){
     
     int i = 0;
     while(i < 50){
-        EEPROM.write(_eepromAdr + i, 0);
+        EEPROM.update(_eepromAdr + i, 0);
         i++;
     }
     

--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -140,6 +140,12 @@ float _inchesToMMConversion =  1;
 bool  useRelativeUnits      =  false;
 bool  stopFlag              =  false;
 bool  pauseFlag             =  false;
+bool  rcvdKinematicSettings =  false;
+bool  rcvdMotorSettings     =  false;
+bool  encoderStepsChanged   =  false;
+bool  zEncoderStepsChanged  =  false;
+// Commands that can safely be executed before machineReady
+char*  safeCommands[] = {'B01', 'B03', 'B04', 'B05', 'B07', 'B12', 'G20', 'G21', 'G90', 'G91'};
 String readyCommandString;                //next command queued up and ready to send
 String gcodeLine;                         //The next individual line of gcode (for example G91 G01 X19 would be run as two lines)
 
@@ -147,6 +153,29 @@ int   lastCommand           =  0;         //Stores the value of the last command
 
 float xTarget = 0;
 float yTarget = 0;
+
+bool machineReady(){
+  bool ret = false;
+  if (rcvdMotorSettings && rcvdKinematicSettings){
+      ret = true;
+  }
+  return ret;
+}
+
+void finalizeMachineSettings(){
+    if(machineReady()){
+        if (encoderStepsChanged){
+            leftAxis.loadPositionFromMemory();
+            rightAxis.loadPositionFromMemory();
+            encoderStepsChanged = false;
+        }
+        if (zEncoderStepsChanged){
+            zAxis.loadPositionFromMemory();
+            zEncoderStepsChanged = false;
+        }
+        kinematics.forward(leftAxis.read(), rightAxis.read(), &xTarget, &yTarget);
+    }
+}
 
 void  returnError(){
     /*
@@ -984,9 +1013,9 @@ void  updateKinematicsSettings(const String& readString){
     }
     
     //propagate the new values
+    rcvdKinematicSettings = true;
     kinematics.recomputeGeometry();
-    
-    kinematics.forward(leftAxis.read(), rightAxis.read(), &xTarget, &yTarget);
+    finalizeMachineSettings();
     
     Serial.println(F("Kinematics Settings Loaded"));
 }
@@ -1014,7 +1043,7 @@ void updateMotorSettings(const String& readString){
     float KpV                = extractGcodeValue(readString, 'V', -1);
     float KiV                = extractGcodeValue(readString, 'W', -1);
     float KdV                = extractGcodeValue(readString, 'X', -1);
-    
+      
     //Write the PID values to the axis if new ones have been received
     if (KpPos != -1){
         leftAxis.setPIDValues(KpPos, KiPos, KdPos, KpV, KiV, KdV);
@@ -1035,13 +1064,28 @@ void updateMotorSettings(const String& readString){
     if (encoderSteps != -1){
         leftAxis.changeEncoderResolution(encoderSteps);
         rightAxis.changeEncoderResolution(encoderSteps);
-        leftAxis.loadPositionFromMemory();
-        rightAxis.loadPositionFromMemory();
+        encoderStepsChanged = true;
     }
     if (zEncoderSteps != -1){
         zAxis.changeEncoderResolution(zEncoderSteps);
-        zAxis.loadPositionFromMemory();
+        zEncoderStepsChanged = true;
     }
+    
+    rcvdMotorSettings = true;
+    finalizeMachineSettings(); 
+    Serial.println(F("Motor Settings Loaded"));
+}
+
+bool isSafeCommand(const String& readString){
+    bool ret = false;
+    char command[4] = readString.substring(0, 3);
+    for(int i = 0; i < sizeof(safeCommands); i++){
+       if(safeCommands[i] == command){
+           ret = true;
+           break;
+       }
+    }
+    return ret;
 }
 
 void  executeGcodeLine(const String& gcodeLine){
@@ -1051,6 +1095,11 @@ void  executeGcodeLine(const String& gcodeLine){
     included on the front of the line, the code from the prevous line will be added.
     
     */
+    
+    if (!machineReady() && !isSafeCommand(gcodeLine)){
+        Serial.println(F("Unable to execute command, machine settings not yet received"));
+        return;
+    }
     
     //Handle B-codes
     

--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -145,7 +145,7 @@ bool  rcvdMotorSettings     =  false;
 bool  encoderStepsChanged   =  false;
 bool  zEncoderStepsChanged  =  false;
 // Commands that can safely be executed before machineReady
-char*  safeCommands[] = {'B01', 'B03', 'B04', 'B05', 'B07', 'B12', 'G20', 'G21', 'G90', 'G91'};
+String safeCommands[] = {"B01", "B03", "B04", "B05", "B07", "B12", "G20", "G21", "G90", "G91"};
 String readyCommandString;                //next command queued up and ready to send
 String gcodeLine;                         //The next individual line of gcode (for example G91 G01 X19 would be run as two lines)
 
@@ -1078,7 +1078,7 @@ void updateMotorSettings(const String& readString){
 
 bool isSafeCommand(const String& readString){
     bool ret = false;
-    char command[4] = readString.substring(0, 3);
+    String command = readString.substring(0, 3);
     for(int i = 0; i < sizeof(safeCommands); i++){
        if(safeCommands[i] == command){
            ret = true;
@@ -1322,8 +1322,12 @@ void  interpretCommandString(const String& cmdString){
     
     int firstG;  
     int secondG;
-    
-    if (cmdString[0] == 'B'){                   //If the command is a B command
+    String cmdStringTrim = cmdString;
+    cmdStringTrim.trim();
+    if (cmdStringTrim.length() <= 0){
+        // Nothing to process, likely a blank startup line
+    }
+    else if (cmdString[0] == 'B'){                   //If the command is a B command
         Serial.print(cmdString);
         executeGcodeLine(cmdString);
     }


### PR DESCRIPTION
Requires that both the B12 and B03 commands be received prior to executing any unsafe commands.  A whitelist of safe commands (those that can safely be executed without machine data) is included and must be added to if new safe commands are added in the future.

Also swiches to get/put/update EEPROM commands which saves us from having custom made read/write float commands as well as ensures that writes to the EEPROM are only done when necessary.

Finally, gracefully handles receiving empty commands.

This solves a major bug in which EEPROM data could be overwritten by other processes on the host computer.
Fixes #291 