### PR TITLE
RingBuffer updates and add numberOfLines

### DIFF
--- a/cnc_ctrl_v1/RingBuffer.h
+++ b/cnc_ctrl_v1/RingBuffer.h
@@ -29,6 +29,7 @@
             void  print();
             char  read();
             int   length();
+            int   numberOfLines();
             int   spaceAvailable();
             void  empty();
             String readLine();


### PR DESCRIPTION
- In RingBuffer::read(), move _incrementBeginning() inside else statement.  If the buffer is empty, we definitely don't want to move the beginning pointer.
- Add RingBuffer::numberOfLines() to count the number of full lines in the buffer, update RingBuffer::readLine() to use this count instead of looking for a full line.
- Update RingBuffer::print() to dump the entire buffer contents, update RingBuffer::_incrementEnd() to use RingBuffer::print() if there is a buffer overflow to print buffer info and contents instead of using its own separate code.
- Fix comments for RingBuffer::spaceAvailable() and RingBuffer::length().