### PR TITLE
G-code lastCommand remember only G00 through G03

### DIFF
--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -1248,25 +1248,20 @@ void  executeGcodeLine(const String& gcodeLine){
    
     int gNumber = extractGcodeValue(gcodeLine,'G', -1);
     
-    if (gNumber != -1){                                     //If the line has a valid G number
-        lastCommand = gNumber;                              //remember it for next time
-    }
-    else{                                                   //If the line does not have a gcommand
-        gNumber = lastCommand;                              //apply the last one
+    if (gNumber == -1){               // If the line does not have a G command
+        gNumber = lastCommand;        // apply the last one
     }
     
     switch(gNumber){
-        case 0:
+        case 0:   // Rapid positioning
+        case 1:   // Linear interpolation
             G1(gcodeLine, gNumber);
+            lastCommand = gNumber;    // remember G number for next time
             break;
-        case 1:
-            G1(gcodeLine, gNumber);
-            break;
-        case 2:
+        case 2:   // Circular interpolation, clockwise
+        case 3:   // Circular interpolation, counterclockwise
             G2(gcodeLine, gNumber);
-            break;
-        case 3:
-            G2(gcodeLine, gNumber);
+            lastCommand = gNumber;    // remember G number for next time
             break;
         case 10:
             G10(gcodeLine);


### PR DESCRIPTION
Fix G-code lastCommand to remember only G00 through G03 for when future lines omit the G number. (It doesn't make sense to remember other G numbers as they are not movement commands.)

Also combined cases for G00 and G01, since both use G1(), and G02 and G03, since both use G2().

Sample G-code snippet (Generated with HeeksCAD 1,1) to illustrate the need for G-code lastCommand to remember only G00 through G03 for when future lines omit the G number:
...
G00 Z5
(tool change to 3.175 mm End Mill)
T4 M06 G43
(Sketch 24)
X37.123 Y73.523 S10000 M03
Z2
G01 Z-1.5 F800
...

Comments:
The line after the (Sketch 24) comment does not have a G number. This is a continuation of G00 prior to the tool change. The tool change line beginning with T4 includes G43 (Use Tool Length Offset from Tool Table). It doesn't make sense to remember G43 since it isn't a motion code. If we remember only G00 through G03, then the G00 will correctly be applied to the line after the (Sketch 24) comment.