### PR TITLE
Command String improvements

### DIFF
--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -1315,6 +1315,10 @@ void  interpretCommandString(const String& cmdString){
     /*
     
     Splits a string into lines of gcode which begin with 'G'
+
+    Assumptions:
+        Leading and trailing white space has already been removed from cmdString
+        cmdString has been converted to upper case
     
     */
     
@@ -1322,33 +1326,31 @@ void  interpretCommandString(const String& cmdString){
     
     int firstG;  
     int secondG;
-    String cmdStringTrim = cmdString;
-    cmdStringTrim.trim();
-    if (cmdStringTrim.length() <= 0){
-        // Nothing to process, likely a blank startup line
-    }
-    else if (cmdString[0] == 'B'){                   //If the command is a B command
-        Serial.print(cmdString);
-        executeGcodeLine(cmdString);
-    }
-    else{
-        while(cmdString.length() > 0){          //Extract each line of gcode from the string
-            firstG  = findNextG(cmdString, 0);
-            secondG = findNextG(cmdString, firstG + 1);
-            
-            if(firstG == cmdString.length()){   //If the line contains no G letters
-                firstG = 0;                     //send the whole line
+
+    if (cmdString.length() > 0) {
+        if (cmdString[0] == 'B'){                   //If the command is a B command
+            Serial.print(cmdString);
+            executeGcodeLine(cmdString);
+        }
+        else{
+            while(cmdString.length() > 0){          //Extract each line of gcode from the string
+                firstG  = findNextG(cmdString, 0);
+                secondG = findNextG(cmdString, firstG + 1);
+                
+                if(firstG == cmdString.length()){   //If the line contains no G letters
+                    firstG = 0;                     //send the whole line
+                }
+                
+                gcodeLine = cmdString.substring(firstG, secondG);
+                
+                if (gcodeLine.length() > 1){
+                    Serial.println(gcodeLine);
+                    executeGcodeLine(gcodeLine);
+                }
+                
+                cmdString = cmdString.substring(secondG, cmdString.length());
+
             }
-            
-            gcodeLine = cmdString.substring(firstG, secondG);
-            
-            if (gcodeLine.length() > 1){
-                Serial.println(gcodeLine);
-                executeGcodeLine(gcodeLine);
-            }
-            
-            cmdString = cmdString.substring(secondG, cmdString.length());
-            
         }
     }
     

--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -1329,7 +1329,7 @@ void  interpretCommandString(const String& cmdString){
 
     if (cmdString.length() > 0) {
         if (cmdString[0] == 'B'){                   //If the command is a B command
-            Serial.print(cmdString);
+            Serial.println(cmdString);
             executeGcodeLine(cmdString);
         }
         else{

--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -1341,6 +1341,12 @@ void  interpretCommandString(const String& cmdString){
                     firstG = 0;                     //send the whole line
                 }
                 
+                if (firstG > 0) {                   //If there is something before the first 'G'
+                    gcodeLine = cmdString.substring(0, firstG);
+                    Serial.println(gcodeLine);
+                    executeGcodeLine(gcodeLine);  // execute it first
+                }
+                
                 gcodeLine = cmdString.substring(firstG, secondG);
                 
                 if (gcodeLine.length() > 1){

--- a/cnc_ctrl_v1/cnc_ctrl_v1.ino
+++ b/cnc_ctrl_v1/cnc_ctrl_v1.ino
@@ -50,6 +50,7 @@ void loop(){
     readyCommandString = ringBuffer.readLine();
     
     if (readyCommandString.length() > 0){
+        readyCommandString.trim();  // remove leading and trailing white space
         readyCommandString.toUpperCase();
         interpretCommandString(readyCommandString);
         readyCommandString = "";


### PR DESCRIPTION
Combines several commits improving command string handling:
- change string trim to save memory and be more useful
- (minor, cosmetic) add line break after cmdString for Bcode
- execute beginning of command string that doesn't start with "G" but contains "G" later in the string