### PR TITLE
Reduce chance of ring buffer overflow - _signalReady

### DIFF
--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -226,7 +226,9 @@ void  _signalReady(){
     
     */
     
-    Serial.println(F("ok"));
+    if (ringBuffer.numberOfLines() < 2) {         // if there are fewer than 2 lines in the buffer
+        Serial.println(F("ok"));                  // request new code
+    }
 }
 
 void  _watchDog(){

--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -135,6 +135,8 @@ Axis zAxis    (ENB, IN3, IN4, ENCODER2B, ENCODER2A, "Z",     Z_EEPROM_ADR);
 Kinematics kinematics;
 RingBuffer ringBuffer;
 
+int expectedMaxLineLength   = 60;   // expected maximum Gcode line length in characters, including line ending character(s)
+
 float feedrate              =  500;
 float _inchesToMMConversion =  1;
 bool  useRelativeUnits      =  false;
@@ -226,8 +228,9 @@ void  _signalReady(){
     
     */
     
-    if (ringBuffer.numberOfLines() < 2) {         // if there are fewer than 2 lines in the buffer
-        Serial.println(F("ok"));                  // request new code
+    if ( (ringBuffer.spaceAvailable() > expectedMaxLineLength)    // if there is space in the buffer to accept the expected maximum line length
+          && (ringBuffer.numberOfLines() < 4) ) {                 // and if there are fewer than 4 lines in the buffer
+        Serial.println(F("ok"));                                  // then request new code
     }
 }
 


### PR DESCRIPTION
Now that we have the updated RingBuffer with numberOfLines() from pull request #295, here is a suggested improvement to reduce the change of ring buffer overflow.  This prevents _signalReady() from sending "ok" to Ground Control if there are 2 or more lines already in the buffer.  This is probably not necessary since pull request #297 was also merged, but it shouldn't hurt, and it might be helpful if future changes inadvertently start putting additional lines in the buffer.