### PR TITLE
Add maslowDelay

### DIFF
--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -320,6 +320,26 @@ void pause(){
     }    
 }
 
+void maslowDelay(unsigned long waitTimeMs) {
+  /*
+   * Provides a time delay while holding the machine position, reading serial commands,
+   * and periodically sending the machine position to Ground Control.  This prevents
+   * Ground Control from thinking that the connection is lost.
+   * 
+   * This is similar to the pause() command above, but provides a time delay rather than
+   * waiting for the user (through Ground Control) to tell the machine to continue.
+   */
+   
+    unsigned long startTime  = millis();
+    
+    while ((millis() - startTime) < waitTimeMs){
+        delay(1);
+        holdPosition();
+        readSerialCommands();
+        returnPoz(xTarget, yTarget, zAxis.read());
+    }
+}
+
 bool checkForProbeTouch(const int& probePin) {
   /*
       Check to see if AUX4 has gone LOW
@@ -602,14 +622,8 @@ int   G1(const String& readString, int G0orG1){
             pause(); //Wait until the z-axis is adjusted
             
             zAxis.set(zgoto);
-            
-            int    waitTimeMs = 1000;
-            double startTime  = millis();
-            
-            while (millis() - startTime < waitTimeMs){
-                delay(1);
-                holdPosition();
-            } 
+
+            maslowDelay(1000);
         }
     }
     


### PR DESCRIPTION
Adds a maslowDelay() function to allow the firmware to delay for a certain amount of time while maintaining communication with Ground Control.

Also replaces the wait loop in G1() with a call to maslowDelay().  The wait loop in G1() does not continue communication with Ground Control, which can cause Ground Control to think that the connection is lost.  This can be illustrated as follows:
- Change waitTimeMs in the wait loop in G1() from 1000 (1 second) to 10000 (10 seconds) and upload to the Arduino
- Run Ground Control and turn off "z-axis installed" in settings
- Run a Gcode file in Ground Control
- After the first manual z-axis adjustment, Ground Control will complain that the connection has been lost

To illustrate that this fix works, after making the change to use maslowDelay() in G1(), change the argument passed to maslowDelay() from 1000 (1 second) to 10000 (10 seconds) and run Ground Control as above.  There is a much longer delay after each manual z-axis adjustment, but the Arduino still communicates with Ground Control and the connection is maintained.

