### PR TITLE
Add B Functions for Testing PID Settings

### DIFF
--- a/cnc_ctrl_v1/Axis.cpp
+++ b/cnc_ctrl_v1/Axis.cpp
@@ -144,6 +144,16 @@ void   Axis::setPIDValues(float KpPos, float KiPos, float KdPos, float KpV, floa
     motorGearboxEncoder.setPIDValues(KpV, KiV, KdV);
 }
 
+String  Axis::getPIDString(){
+    /*
+    
+    Get PID tuning values
+    
+    */
+    String PIDString = "Kp=";
+    return PIDString + _Kp + ",Ki=" + _Ki + ",Kd=" + _Kd;
+}
+
 void   Axis::setPIDAggressiveness(float aggressiveness){
     /*
     

--- a/cnc_ctrl_v1/Axis.cpp
+++ b/cnc_ctrl_v1/Axis.cpp
@@ -98,7 +98,6 @@ int    Axis::set(const float& newAxisPosition){
 
 void   Axis::computePID(){
     
-    
     if (_disableAxisForTesting){
         return;
     }
@@ -109,20 +108,24 @@ void   Axis::computePID(){
     
     _pidInput      =  motorGearboxEncoder.encoder.read()/_encoderSteps;
     
-    _pidController.Compute();
-    
-    motorGearboxEncoder.write(_pidOutput);
-    
-    /*if(_axisName[0] == 'L'){
-        Serial.println("*");
-        Serial.println(_pidInput);
-        Serial.println(_pidSetpoint);
-        Serial.println(_pidOutput);
-    }*/
-    
-    
+    if (_pidController.Compute()){
+        // Only write output if the PID calculation was performed
+        motorGearboxEncoder.write(_pidOutput);
+    }
     
     motorGearboxEncoder.computePID();
+    
+}
+
+void   Axis::disablePositionPID(){
+    
+    _pidController.SetMode(MANUAL);
+    
+}
+
+void   Axis::enablePositionPID(){
+    
+    _pidController.SetMode(AUTOMATIC);
     
 }
 

--- a/cnc_ctrl_v1/Axis.h
+++ b/cnc_ctrl_v1/Axis.h
@@ -40,6 +40,8 @@
             float  error();
             float  setpoint();
             void   computePID();
+            void   disablePositionPID();
+            void   enablePositionPID();
             void   setPIDAggressiveness(float aggressiveness);
             void   test();
             void   changePitch(const float& newPitch);

--- a/cnc_ctrl_v1/Axis.h
+++ b/cnc_ctrl_v1/Axis.h
@@ -51,6 +51,7 @@
             MotorGearboxEncoder    motorGearboxEncoder;
             void   setPIDValues(float Kp, float Ki, float Kd, float KpV, float KiV, float KdV);
             void   loadPositionFromMemory();
+            String     getPIDString();
             
         private:
             int        _PWMread(int pin);

--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -1238,6 +1238,7 @@ void PIDTestVelocity(Axis* axis, const float start, const float stop, const floa
     // Print end of log, and update axis for use again
     Serial.println(F("--PID Velocity Test Stop--\n"));
     axis->write(axis->read());
+    axis->detach();
     axis->enablePositionPID();
     kinematics.forward(leftAxis.read(), rightAxis.read(), &xTarget, &yTarget);
 }

--- a/cnc_ctrl_v1/MotorGearboxEncoder.cpp
+++ b/cnc_ctrl_v1/MotorGearboxEncoder.cpp
@@ -138,6 +138,16 @@ void  MotorGearboxEncoder::setPIDValues(float KpV, float KiV, float KdV){
     _negPIDController.SetTunings(_Kp, _Ki, _Kd);
 }
 
+String  MotorGearboxEncoder::getPIDString(){
+    /*
+    
+    Get PID tuning values
+    
+    */
+    String PIDString = "Kp=";
+    return PIDString + _Kp + ",Ki=" + _Ki + ",Kd=" + _Kd;
+}
+
 void MotorGearboxEncoder::setPIDAggressiveness(float aggressiveness){
     /*
     
@@ -211,4 +221,11 @@ void MotorGearboxEncoder::setName(const String& newName){
     Set the name for the object
     */
     _motorName = newName;
+}
+
+String MotorGearboxEncoder::name(){
+    /*
+    Get the name for the object
+    */
+    return _motorName;
 }

--- a/cnc_ctrl_v1/MotorGearboxEncoder.h
+++ b/cnc_ctrl_v1/MotorGearboxEncoder.h
@@ -32,10 +32,12 @@
             void       write(const float& speed);
             void       computePID();
             void       setName(const String& newName);
+            String     name();
             void       initializePID();
             void       setPIDAggressiveness(float aggressiveness);
             void       setPIDValues(float KpV, float KiV, float KdV);
             void       setEncoderResolution(float resolution);
+            String     getPIDString();
         private:
             double     _targetSpeed;
             double     _currentSpeed;


### PR DESCRIPTION
Adds B13&14 functions which allow a user to request a series of stepped movements on a particular axis.  During these movements the error of the axis during the movement is reported on a series of lines which can be graphed by the user.

These functions are somewhat rudimentary, but they are very helpful for initial testing of PID settings.  

I have started to write some documentation of the Tuning process here:

https://github.com/MaslowCNC/Firmware/wiki/PID-Tuning