### PR TITLE
Upgrade PID Library to v1.2.1

### DIFF
--- a/cnc_ctrl_v1/Axis.cpp
+++ b/cnc_ctrl_v1/Axis.cpp
@@ -31,7 +31,7 @@ Axis::Axis(const int& pwmPin, const int& directionPin1, const int& directionPin2
 motorGearboxEncoder(pwmPin, directionPin1, directionPin2, encoderPin1, encoderPin2)
 {
     
-    _pidController.setup(&_pidInput, &_pidOutput, &_pidSetpoint, 0, 0, 0, REVERSE);
+    _pidController.setup(&_pidInput, &_pidOutput, &_pidSetpoint, 0, 0, 0, P_ON_E, REVERSE);
     
     //initialize variables
     _direction    = FORWARD;
@@ -136,7 +136,7 @@ void   Axis::setPIDValues(float KpPos, float KiPos, float KdPos, float KpV, floa
     _Ki = KiPos;
     _Kd = KdPos;
     
-    _pidController.SetTunings(_Kp, _Ki, _Kd);
+    _pidController.SetTunings(_Kp, _Ki, _Kd, P_ON_E);
     
     motorGearboxEncoder.setPIDValues(KpV, KiV, KdV);
 }

--- a/cnc_ctrl_v1/MotorGearboxEncoder.cpp
+++ b/cnc_ctrl_v1/MotorGearboxEncoder.cpp
@@ -34,8 +34,8 @@ encoder(encoderPin1,encoderPin2)
     motor.write(0);
     
     //initialize the PID
-    _posPIDController.setup(&_currentSpeed, &_pidOutput, &_targetSpeed, _Kp, _Ki, _Kd, DIRECT);
-    _negPIDController.setup(&_currentSpeed, &_pidOutput, &_targetSpeed, _Kp, _Ki, _Kd, DIRECT);
+    _posPIDController.setup(&_currentSpeed, &_pidOutput, &_targetSpeed, _Kp, _Ki, _Kd, P_ON_E, DIRECT);
+    _negPIDController.setup(&_currentSpeed, &_pidOutput, &_targetSpeed, _Kp, _Ki, _Kd, P_ON_E, DIRECT);
     initializePID();
     
     
@@ -134,8 +134,8 @@ void  MotorGearboxEncoder::setPIDValues(float KpV, float KiV, float KdV){
     _Ki = KiV;
     _Kd = KdV;
     
-    _posPIDController.SetTunings(_Kp, _Ki, _Kd);
-    _negPIDController.SetTunings(_Kp, _Ki, _Kd);
+    _posPIDController.SetTunings(_Kp, _Ki, _Kd, P_ON_E);
+    _negPIDController.SetTunings(_Kp, _Ki, _Kd, P_ON_E);
 }
 
 void MotorGearboxEncoder::setPIDAggressiveness(float aggressiveness){
@@ -146,8 +146,8 @@ void MotorGearboxEncoder::setPIDAggressiveness(float aggressiveness){
     
     */
     
-    _posPIDController.SetTunings(aggressiveness*_Kp, _Ki, _Kd);
-    _negPIDController.SetTunings(aggressiveness*_Kp, _Ki, _Kd);
+    _posPIDController.SetTunings(aggressiveness*_Kp, _Ki, _Kd, P_ON_E);
+    _negPIDController.SetTunings(aggressiveness*_Kp, _Ki, _Kd, P_ON_E);
     
 }
 

--- a/cnc_ctrl_v1/PID_v1.h
+++ b/cnc_ctrl_v1/PID_v1.h
@@ -1,6 +1,6 @@
 #ifndef PID_v1_h
 #define PID_v1_h
-#define LIBRARY_VERSION	1.1.1
+#define LIBRARY_VERSION	1.2.1
 
 class PID
 {
@@ -13,13 +13,19 @@ class PID
   #define MANUAL	0
   #define DIRECT  0
   #define REVERSE  1
+  #define P_ON_M 0
+  #define P_ON_E 1
 
   //commonly used functions **************************************************************************
     
     PID();
     
     void setup(double*, double*, double*,        // * constructor.  links the PID to the Input, Output, and 
-        const double&, const double&, const double&, const int&);     //   Setpoint.  Initial tuning parameters are also set here
+        const double&, const double&, const double&, const int&, const int&);//   Setpoint.  Initial tuning parameters are also set here.
+                                          //   (overload for specifying proportional mode)
+
+    PID(double*, double*, double*,        // * constructor.  links the PID to the Input, Output, and 
+        double, double, double, int);     //   Setpoint.  Initial tuning parameters are also set here
 	
     void SetMode(const int& Mode);               // * sets PID to either Manual (0) or Auto (non-0)
 
@@ -38,6 +44,9 @@ class PID
     void SetTunings(const double&, const double&,       // * While most users will set the tunings once in the 
                     const double&);         	  //   constructor, this function gives the user the option
                                           //   of changing tunings during runtime for Adaptive control
+    void SetTunings(const double&, const double&,       // * overload for specifying proportional mode
+                    const double&, const int&);         	  
+
 	void SetControllerDirection(const int&);	  // * Sets the Direction, or "Action" of the controller. DIRECT
 										  //   means the output will increase when error is positive. REVERSE
 										  //   means the opposite.  it's very unlikely that this will be needed
@@ -70,6 +79,7 @@ class PID
     double kd;                  // * (D)erivative Tuning Parameter
 
 	int controllerDirection;
+	int pOn;
 
     double *myInput;              // * Pointers to the Input, Output, and Setpoint variables
     double *myOutput;             //   This creates a hard link between the variables and the 
@@ -77,11 +87,11 @@ class PID
                                   //   what these values are.  with pointers we'll just know.
 			  
 	unsigned long lastTime;
-	double ITerm, lastInput;
+	double outputSum, lastInput;
 
 	unsigned long SampleTime;
 	double outMin, outMax;
-	bool inAuto;
+	bool inAuto, pOnE;
 };
 #endif
 


### PR DESCRIPTION
This does not alter the functionality of the library nor how it is used in Maslow.  Specifically the proportional aspect of the PID calculation is still handled the same way it always has been.

Fixes #304 