### PR TITLE
Don't Run PID Calculation if Motors are Detached/Unpowered

### DIFF
--- a/cnc_ctrl_v1/Axis.cpp
+++ b/cnc_ctrl_v1/Axis.cpp
@@ -98,8 +98,7 @@ int    Axis::set(const float& newAxisPosition){
 
 void   Axis::computePID(){
     
-    
-    if (_disableAxisForTesting){
+    if (_disableAxisForTesting || !motorGearboxEncoder.motor.attached()){
         return;
     }
     


### PR DESCRIPTION
This was causing the integrator term to wind up while the machine was on, but not running.

Fixes #302