### PR TITLE
Allow Weighting of Proportional on Error/Measurement

### DIFF
--- a/cnc_ctrl_v1/Axis.cpp
+++ b/cnc_ctrl_v1/Axis.cpp
@@ -126,7 +126,7 @@ void   Axis::computePID(){
     
 }
 
-void   Axis::setPIDValues(float KpPos, float KiPos, float KdPos, float KpV, float KiV, float KdV){
+void   Axis::setPIDValues(float KpPos, float KiPos, float KdPos, float propWeight, float KpV, float KiV, float KdV){
     /*
     
     Sets the positional PID values for the axis
@@ -136,7 +136,7 @@ void   Axis::setPIDValues(float KpPos, float KiPos, float KdPos, float KpV, floa
     _Ki = KiPos;
     _Kd = KdPos;
     
-    _pidController.SetTunings(_Kp, _Ki, _Kd, P_ON_E);
+    _pidController.SetTunings(_Kp, _Ki, _Kd, propWeight);
     
     motorGearboxEncoder.setPIDValues(KpV, KiV, KdV);
 }

--- a/cnc_ctrl_v1/Axis.h
+++ b/cnc_ctrl_v1/Axis.h
@@ -47,7 +47,7 @@
             bool   attached();
             void   wipeEEPROM();
             MotorGearboxEncoder    motorGearboxEncoder;
-            void   setPIDValues(float Kp, float Ki, float Kd, float KpV, float KiV, float KdV);
+            void   setPIDValues(float Kp, float Ki, float Kd, float propWeight, float KpV, float KiV, float KdV);
             void   loadPositionFromMemory();
             
         private:

--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -1069,6 +1069,7 @@ void updateMotorSettings(const String& readString){
     float zDistPerRot        = extractGcodeValue(readString, 'N', -1);
     int zEncoderSteps        = extractGcodeValue(readString, 'P', -1);
     
+    float propWeight         = extractGcodeValue(readString, 'R', -1);
     float KpPos              = extractGcodeValue(readString, 'S', -1);
     float KiPos              = extractGcodeValue(readString, 'T', -1);
     float KdPos              = extractGcodeValue(readString, 'U', -1);
@@ -1078,9 +1079,9 @@ void updateMotorSettings(const String& readString){
       
     //Write the PID values to the axis if new ones have been received
     if (KpPos != -1){
-        leftAxis.setPIDValues(KpPos, KiPos, KdPos, KpV, KiV, KdV);
-        rightAxis.setPIDValues(KpPos, KiPos, KdPos, KpV, KiV, KdV);
-        zAxis.setPIDValues(KpPos, KiPos, KdPos, KpV, KiV, KdV);
+        leftAxis.setPIDValues(KpPos, KiPos, KdPos, propWeight, KpV, KiV, KdV);
+        rightAxis.setPIDValues(KpPos, KiPos, KdPos, propWeight, KpV, KiV, KdV);
+        zAxis.setPIDValues(KpPos, KiPos, KdPos, propWeight, KpV, KiV, KdV);
     }
     
     //Change the motor properties in cnc_funtions if new values have been sent

--- a/cnc_ctrl_v1/PID_v1.cpp
+++ b/cnc_ctrl_v1/PID_v1.cpp
@@ -23,7 +23,7 @@ PID::PID()
 }
 
 void PID::setup(double* Input, double* Output, double* Setpoint,
-        const double& Kp, const double& Ki, const double& Kd, const int& POn, const int& ControllerDirection)
+        const double& Kp, const double& Ki, const double& Kd, const double& POn, const int& ControllerDirection)
 {
 
     myOutput = Output;
@@ -65,14 +65,14 @@ bool PID::Compute()
     outputSum+= (ki * error);
 
     /*Add Proportional on Measurement, if P_ON_M is specified*/
-    if(!pOnE) outputSum-= kp * dInput;
+    if(pOnM) outputSum-= pOnMKp * dInput;
 
     if(outputSum > outMax) outputSum= outMax;
     else if(outputSum < outMin) outputSum= outMin;
 
     /*Add Proportional on Error, if P_ON_E is specified*/
     double output;
-    if(pOnE) output = kp * error;
+    if(pOnE) output = pOnEKp * error;
     else output = 0;
 
     /*Compute Rest of PID Output*/
@@ -96,12 +96,12 @@ bool PID::Compute()
  * it's called automatically from the constructor, but tunings can also
  * be adjusted on the fly during normal operation
  ******************************************************************************/
-void PID::SetTunings(const double& Kp, const double& Ki, const double& Kd, const int& POn)
+void PID::SetTunings(const double& Kp, const double& Ki, const double& Kd, const double& pOn)
 {
-   if (Kp<0 || Ki<0 || Kd<0) return;
+   if (Kp<0 || Ki<0 || Kd<0 || pOn<0 || pOn>1) return;
 
-   pOn = POn;
-   pOnE = POn == P_ON_E;
+   pOnE = pOn>0; //some p on error is desired;
+   pOnM = pOn<1; //some p on measurement is desired;  
 
    dispKp = Kp; dispKi = Ki; dispKd = Kd;
 
@@ -116,6 +116,8 @@ void PID::SetTunings(const double& Kp, const double& Ki, const double& Kd, const
       ki = (0 - ki);
       kd = (0 - kd);
    }
+   pOnEKp = pOn * kp; 
+   pOnMKp = (1 - pOn) * kp;
 }
 
 /* SetSampleTime(...) *********************************************************

--- a/cnc_ctrl_v1/PID_v1.h
+++ b/cnc_ctrl_v1/PID_v1.h
@@ -15,13 +15,15 @@ class PID
   #define REVERSE  1
   #define P_ON_M 0
   #define P_ON_E 1
+  bool pOnE = true, pOnM = false;
+  double pOnEKp, pOnMKp;
 
   //commonly used functions **************************************************************************
     
     PID();
     
     void setup(double*, double*, double*,        // * constructor.  links the PID to the Input, Output, and 
-        const double&, const double&, const double&, const int&, const int&);//   Setpoint.  Initial tuning parameters are also set here.
+        const double&, const double&, const double&, const double&, const int&);//   Setpoint.  Initial tuning parameters are also set here.
                                           //   (overload for specifying proportional mode)
 
     PID(double*, double*, double*,        // * constructor.  links the PID to the Input, Output, and 
@@ -45,7 +47,7 @@ class PID
                     const double&);         	  //   constructor, this function gives the user the option
                                           //   of changing tunings during runtime for Adaptive control
     void SetTunings(const double&, const double&,       // * overload for specifying proportional mode
-                    const double&, const int&);         	  
+                    const double&, const double&);         	  
 
 	void SetControllerDirection(const int&);	  // * Sets the Direction, or "Action" of the controller. DIRECT
 										  //   means the output will increase when error is positive. REVERSE
@@ -91,7 +93,7 @@ class PID
 
 	unsigned long SampleTime;
 	double outMin, outMax;
-	bool inAuto, pOnE;
+	bool inAuto;
 };
 #endif
 


### PR DESCRIPTION
Enables weighting of the proportional calculation method.  1 = proportional on error, 0 = proportional on measurement.  Any fraction in between balances the two options.

Code was a suggestion from the author of the PID library:
http://brettbeauregard.com/blog/2017/06/proportional-on-measurement-the-code/

Must be merged with changes to Ground Control as well, https://github.com/MaslowCNC/GroundControl/pull/426.