### PR TITLE
Fix Compiler Warnings that Appear with Default Settings

### DIFF
--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -1636,7 +1636,7 @@ int   findNextGM(const String& readString, const int& startingPoint){
     return nextGIndex;
 }
 
-void  interpretCommandString(const String& cmdString){
+void  interpretCommandString(String& cmdString){
     /*
     
     Splits a string into lines of gcode which begin with 'G' or 'M', executing each in order

--- a/cnc_ctrl_v1/PID_v1.cpp
+++ b/cnc_ctrl_v1/PID_v1.cpp
@@ -22,7 +22,7 @@ PID::PID()
 	inAuto = false;
 }
 
-void PID::setup(double* Input, double* Output, double* Setpoint,
+void PID::setup(volatile double* Input, volatile double* Output, volatile double* Setpoint,
         const double& Kp, const double& Ki, const double& Kd, const int& POn, const int& ControllerDirection)
 {
 

--- a/cnc_ctrl_v1/PID_v1.h
+++ b/cnc_ctrl_v1/PID_v1.h
@@ -20,7 +20,7 @@ class PID
     
     PID();
     
-    void setup(double*, double*, double*,        // * constructor.  links the PID to the Input, Output, and 
+    void setup(volatile double*, volatile double*, volatile double*,        // * constructor.  links the PID to the Input, Output, and 
         const double&, const double&, const double&, const int&, const int&);//   Setpoint.  Initial tuning parameters are also set here.
                                           //   (overload for specifying proportional mode)
 
@@ -81,9 +81,9 @@ class PID
 	int controllerDirection;
 	int pOn;
 
-    double *myInput;              // * Pointers to the Input, Output, and Setpoint variables
-    double *myOutput;             //   This creates a hard link between the variables and the 
-    double *mySetpoint;           //   PID, freeing the user from having to constantly tell us
+    volatile double *myInput;              // * Pointers to the Input, Output, and Setpoint variables
+    volatile double *myOutput;             //   This creates a hard link between the variables and the 
+    volatile double *mySetpoint;           //   PID, freeing the user from having to constantly tell us
                                   //   what these values are.  with pointers we'll just know.
 			  
 	unsigned long lastTime;


### PR DESCRIPTION
The default installation of the arduino compiler will display
some 'default' level of warnings.  This commit fixes those
errors so that no warnings are displayed by default.

There are additional warnings that can be seen selecting the
'All' setting, this does not fix all of those.

Fixes #290