### PR TITLE
Improvements to the Movement Calculations and PID Controllers

### DIFF
--- a/cnc_ctrl_v1/Axis.cpp
+++ b/cnc_ctrl_v1/Axis.cpp
@@ -60,7 +60,7 @@ void   Axis::loadPositionFromMemory(){
 
 void   Axis::initializePID(){
     _pidController.SetMode(AUTOMATIC);
-    _pidController.SetOutputLimits(-17, 17);
+    _pidController.SetOutputLimits(-20, 20);
     _pidController.SetSampleTime(10);
 }
 

--- a/cnc_ctrl_v1/Axis.cpp
+++ b/cnc_ctrl_v1/Axis.cpp
@@ -34,7 +34,6 @@ motorGearboxEncoder(pwmPin, directionPin1, directionPin2, encoderPin1, encoderPi
     _pidController.setup(&_pidInput, &_pidOutput, &_pidSetpoint, 0, 0, 0, P_ON_E, REVERSE);
     
     //initialize variables
-    _direction    = FORWARD;
     _axisName     = axisName;
     _eepromAdr    = eepromAdr;
     
@@ -101,10 +100,6 @@ void   Axis::computePID(){
 
     if (_disableAxisForTesting || !motorGearboxEncoder.motor.attached()){
         return;
-    }
-    
-    if (_detectDirectionChange(_pidSetpoint)){ //this determines if the axis has changed direction of movement and flushes the accumulator in the PID if it has
-        _pidController.FlipIntegrator();
     }
     
     _pidInput      =  motorGearboxEncoder.encoder.read()/_encoderSteps;
@@ -253,33 +248,6 @@ void   Axis::wipeEEPROM(){
     
     Serial.print(_axisName);
     Serial.println(F(" EEPROM erased"));
-}
-
-int    Axis::_detectDirectionChange(const float& _pidSetpoint){
-    
-    float difference = _pidSetpoint - _oldSetpoint;
-    
-    if(difference == 0){
-        return 0;
-    }
-    
-    int direction;
-    if(difference > 0){
-        direction = 1;
-    }
-    else{
-        direction = 0;
-    }
-    
-    int retVal = 0;
-    if(direction != _oldDir){
-        retVal = 1;
-    }
-    
-    _oldSetpoint = _pidSetpoint;
-    _oldDir = direction;
-    
-    return retVal;
 }
 
 void   Axis::test(){

--- a/cnc_ctrl_v1/Axis.cpp
+++ b/cnc_ctrl_v1/Axis.cpp
@@ -66,7 +66,12 @@ void   Axis::initializePID(){
 
 void    Axis::write(const float& targetPosition){
     
-    _pidSetpoint   =  targetPosition/_mmPerRotation;
+    // Ensure that _pidSetpoint is equal to whole number of encoder steps
+    float steps = (targetPosition/_mmPerRotation) * _encoderSteps;
+    steps = steps * 2;
+    steps = round(steps);
+    steps = steps /2;
+    _pidSetpoint   =  steps/_encoderSteps;
     return;
 }
 

--- a/cnc_ctrl_v1/Axis.h
+++ b/cnc_ctrl_v1/Axis.h
@@ -57,8 +57,6 @@
             int        _PWMread(int pin);
             void       _writeFloat(const unsigned int& addr, const float& x);
             float      _readFloat(const unsigned int& addr);
-            int        _detectDirectionChange(const float& _pidSetpoint);
-            int        _direction;
             int        _encoderPin;
             float      _axisTarget;
             int        _currentAngle;
@@ -73,7 +71,6 @@
             float      _mmPerRotation = 1;
             float      _encoderSteps  = 100;
             float      _oldSetpoint;
-            float      _oldDir;
             bool       _disableAxisForTesting = false;
             String     _axisName;
     };

--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -434,6 +434,7 @@ and G01 commands. The units at this point should all be in mm or mm per minute*/
     long   numberOfStepsTaken         =  0;
     
     while(numberOfStepsTaken < finalNumberOfSteps){
+        unsigned long startTime = millis();
             
         //find the target point for this step
         float whereXShouldBeAtThisStep = xStartingLocation + (numberOfStepsTaken*xStepSize);
@@ -471,7 +472,7 @@ and G01 commands. The units at this point should all be in mm or mm per minute*/
         }
         
         //wait for the step to be completed
-        delay(delayTime);
+        delay(delayTime - (millis() - startTime));
     }
     
     kinematics.inverse(xEnd,yEnd,&aChainLength,&bChainLength);

--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -958,7 +958,6 @@ void  calibrateChainLengths(){
     
     //measure out the left chain
     Serial.println(F("Measuring out left chain"));
-    leftAxis.setPIDAggressiveness(.1);
     singleAxisMove(&leftAxis, ORIGINCHAINLEN, 500);
     
     Serial.print(leftAxis.read());
@@ -968,7 +967,6 @@ void  calibrateChainLengths(){
     
     //measure out the right chain
     Serial.println(F("Measuring out right chain"));
-    rightAxis.setPIDAggressiveness(.1);
     singleAxisMove(&rightAxis, ORIGINCHAINLEN, 500);
     
     Serial.print(rightAxis.read());
@@ -976,9 +974,6 @@ void  calibrateChainLengths(){
     
     kinematics.forward(leftAxis.read(), rightAxis.read(), &xTarget, &yTarget);
     
-    
-    leftAxis.setPIDAggressiveness(1);
-    rightAxis.setPIDAggressiveness(1);
 }
 
 void  setInchesToMillimetersConversion(float newConversionFactor){

--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -963,7 +963,7 @@ void  calibrateChainLengths(){
     
     //measure out the left chain
     Serial.println(F("Measuring out left chain"));
-    singleAxisMove(&leftAxis, ORIGINCHAINLEN, 500);
+    singleAxisMove(&leftAxis, ORIGINCHAINLEN, 800);
     
     Serial.print(leftAxis.read());
     Serial.println(F("mm"));
@@ -972,7 +972,7 @@ void  calibrateChainLengths(){
     
     //measure out the right chain
     Serial.println(F("Measuring out right chain"));
-    singleAxisMove(&rightAxis, ORIGINCHAINLEN, 500);
+    singleAxisMove(&rightAxis, ORIGINCHAINLEN, 800);
     
     Serial.print(rightAxis.read());
     Serial.println(F("mm"));
@@ -1397,10 +1397,7 @@ void  executeBcodeLine(const String& gcodeLine){
         //Directly command each axis to move to a given distance
         float lDist = extractGcodeValue(gcodeLine, 'L', 0);
         float rDist = extractGcodeValue(gcodeLine, 'R', 0);
-		float speed = extractGcodeValue(gcodeLine, 'F', 500);
-        
-        leftAxis.setPIDAggressiveness(.1);
-        rightAxis.setPIDAggressiveness(.1);
+		    float speed = extractGcodeValue(gcodeLine, 'F', 800);
         
         if(useRelativeUnits){
             if(abs(lDist) > 0){
@@ -1414,9 +1411,6 @@ void  executeBcodeLine(const String& gcodeLine){
             singleAxisMove(&leftAxis,  lDist, speed);
             singleAxisMove(&rightAxis, rDist, speed);
         }
-        
-        leftAxis.setPIDAggressiveness(1);
-        rightAxis.setPIDAggressiveness(1);
         
         return;
     }

--- a/cnc_ctrl_v1/MotorGearboxEncoder.cpp
+++ b/cnc_ctrl_v1/MotorGearboxEncoder.cpp
@@ -34,8 +34,7 @@ encoder(encoderPin1,encoderPin2)
     motor.write(0);
     
     //initialize the PID
-    _posPIDController.setup(&_currentSpeed, &_pidOutput, &_targetSpeed, _Kp, _Ki, _Kd, P_ON_E, DIRECT);
-    _negPIDController.setup(&_currentSpeed, &_pidOutput, &_targetSpeed, _Kp, _Ki, _Kd, P_ON_E, DIRECT);
+    _PIDController.setup(&_currentSpeed, &_pidOutput, &_targetSpeed, _Kp, _Ki, _Kd, P_ON_E, DIRECT);
     initializePID();
     
     
@@ -52,14 +51,9 @@ void  MotorGearboxEncoder::write(const float& speed){
 
 void   MotorGearboxEncoder::initializePID(){
     //setup positive PID controller
-    _posPIDController.SetMode(AUTOMATIC);
-    _posPIDController.SetOutputLimits(-255, 255);
-    _posPIDController.SetSampleTime(10);
-    
-    //setup negative PID controller
-    _negPIDController.SetMode(AUTOMATIC);
-    _negPIDController.SetOutputLimits(-255, 255);
-    _negPIDController.SetSampleTime(10);
+    _PIDController.SetMode(AUTOMATIC);
+    _PIDController.SetOutputLimits(-255, 255);
+    _PIDController.SetSampleTime(10);
 }
 
 void  MotorGearboxEncoder::computePID(){
@@ -105,14 +99,8 @@ void  MotorGearboxEncoder::computePID(){
         _targetSpeed = 0;
     }*/
     
-    
-    if(_targetSpeed > 0){
-        _posPIDController.Compute();
-    }
-    else{
-        _negPIDController.Compute();
-    }
-    
+    _PIDController.Compute();
+        
     /*if(_motorName[0] == 'R'){
         //Serial.print(_currentSpeed);
         //Serial.print(" ");
@@ -134,8 +122,7 @@ void  MotorGearboxEncoder::setPIDValues(float KpV, float KiV, float KdV){
     _Ki = KiV;
     _Kd = KdV;
     
-    _posPIDController.SetTunings(_Kp, _Ki, _Kd, P_ON_E);
-    _negPIDController.SetTunings(_Kp, _Ki, _Kd, P_ON_E);
+    _PIDController.SetTunings(_Kp, _Ki, _Kd, P_ON_E);
 }
 
 String  MotorGearboxEncoder::getPIDString(){
@@ -156,8 +143,7 @@ void MotorGearboxEncoder::setPIDAggressiveness(float aggressiveness){
     
     */
     
-    _posPIDController.SetTunings(aggressiveness*_Kp, _Ki, _Kd, P_ON_E);
-    _negPIDController.SetTunings(aggressiveness*_Kp, _Ki, _Kd, P_ON_E);
+    _PIDController.SetTunings(aggressiveness*_Kp, _Ki, _Kd, P_ON_E);
     
 }
 

--- a/cnc_ctrl_v1/MotorGearboxEncoder.cpp
+++ b/cnc_ctrl_v1/MotorGearboxEncoder.cpp
@@ -180,7 +180,7 @@ float MotorGearboxEncoder::computeSpeed(){
     */
     double timeElapsed =  micros() - _lastTimeStamp;
     
-    float    distMoved   =  _runningAverage(encoder.read() - _lastPosition);     //because of quantization noise it helps to average these
+    float    distMoved   =  encoder.read() - _lastPosition; //_runningAverage(encoder.read() - _lastPosition);     //because of quantization noise it helps to average these
     
     //Compute the speed in RPM
     float RPM = (_encoderStepsToRPMScaleFactor*distMoved)/float(timeElapsed);

--- a/cnc_ctrl_v1/MotorGearboxEncoder.cpp
+++ b/cnc_ctrl_v1/MotorGearboxEncoder.cpp
@@ -99,6 +99,10 @@ void  MotorGearboxEncoder::computePID(){
         _targetSpeed = 0;
     }*/
     
+    // Between these speeds the motor is incapable of turning and it only
+    // causes the Iterm in the PID calculation to wind up
+    if (abs(_targetSpeed) <= .5) _targetSpeed = 0;
+
     _PIDController.Compute();
         
     /*if(_motorName[0] == 'R'){

--- a/cnc_ctrl_v1/MotorGearboxEncoder.cpp
+++ b/cnc_ctrl_v1/MotorGearboxEncoder.cpp
@@ -101,7 +101,7 @@ void  MotorGearboxEncoder::computePID(){
     
     // Between these speeds the motor is incapable of turning and it only
     // causes the Iterm in the PID calculation to wind up
-    if (abs(_targetSpeed) <= .5) _targetSpeed = 0;
+    if (abs(_targetSpeed) <= _minimumRPM) _targetSpeed = 0;
 
     _PIDController.Compute();
         

--- a/cnc_ctrl_v1/MotorGearboxEncoder.h
+++ b/cnc_ctrl_v1/MotorGearboxEncoder.h
@@ -46,8 +46,7 @@
             float      _runningAverage(const int& newValue);
             String     _motorName;
             double     _pidOutput;
-            PID        _posPIDController;
-            PID        _negPIDController;
+            PID        _PIDController;
             double     _Kp=0, _Ki=0, _Kd=0;
             float      _encoderStepsToRPMScaleFactor = 7364.0;   //6*10^7 us per minute divided by 8148 steps per revolution
             int        _oldValue1;

--- a/cnc_ctrl_v1/MotorGearboxEncoder.h
+++ b/cnc_ctrl_v1/MotorGearboxEncoder.h
@@ -59,6 +59,7 @@
             int        _oldValue8;
             int        _oldValue9;
             int        _oldValue10;
+            float      _minimumRPM = 0.5;
     };
 
     #endif


### PR DESCRIPTION
**These changes will affect how your current PID tunings work, almost certainly causing them not to work, you will want to merge the corresponding pull request in GC as well, or manually make the changes to your PID tunings**

This makes a number of changes/improvements which include:

- Removing the running average on the input to the PID velocity calculation (this caused oscillations and damped the control reaction and I think averaging is an incorrect solution in control theory anyways)
- Adds a minimum rotation rate for the velocity controller (the motors are unable to turn at this rate, so this only caused integrator windup and noise)
- Ensure that position requests are equal to a whole number of encoder steps (prevents oscillations and integrator windup for unobtainable positions)
- Fix delay in the straight line loop in the movement loop to be consistent (ensures that the controllers are getting steps of equal length in each cycle)
- Fix a few other obscure design issues with the PID controller

Suggested PID Tunings that seem to work well:
Kp Pos = 1100
Ki Pos = 0
Kd Pos= 0
Proportional Weight 1

Kp Velo = 52
Ki Velo = 0
Kd Velo = 0

Corresponding Ground Control PR:
https://github.com/MaslowCNC/GroundControl/pull/430
