### PR TITLE
Fix Compiler Errors; Remove Unused Variables and Functions

### DIFF
--- a/cnc_ctrl_v1/Axis.cpp
+++ b/cnc_ctrl_v1/Axis.cpp
@@ -19,14 +19,11 @@
 #include "Arduino.h"
 #include "Axis.h"
 
-#define FORWARD 1
-#define BACKWARD -1
-
 #define EEPROMVALIDDATA 56
 #define SIZEOFFLOAT      4
 #define SIZEOFLINSEG    17
 
-Axis::Axis(const int& pwmPin, const int& directionPin1, const int& directionPin2, const int& encoderPin1, const int& encoderPin2, const String& axisName, const int& eepromAdr)
+Axis::Axis(const int& pwmPin, const int& directionPin1, const int& directionPin2, const int& encoderPin1, const int& encoderPin2, const char& axisName, const int& eepromAdr)
 :
 motorGearboxEncoder(pwmPin, directionPin1, directionPin2, encoderPin1, encoderPin2)
 {
@@ -91,7 +88,7 @@ float  Axis::setpoint(){
     return _pidSetpoint*_mmPerRotation;
 }
 
-int    Axis::set(const float& newAxisPosition){
+void   Axis::set(const float& newAxisPosition){
     
     //reset everything to the new value
     _axisTarget   =  newAxisPosition/_mmPerRotation;

--- a/cnc_ctrl_v1/Axis.h
+++ b/cnc_ctrl_v1/Axis.h
@@ -26,10 +26,10 @@
 
     class Axis{
         public:
-            Axis(const int& pwmPin, const int& directionPin1, const int& directionPin2, const int& encoderPin1, const int& encoderPin2, const String& axisName, const int& eepromAdr);
+            Axis(const int& pwmPin, const int& directionPin1, const int& directionPin2, const int& encoderPin1, const int& encoderPin2, const char& axisName, const int& eepromAdr);
             void   write(const float& targetPosition);
             float  read();
-            int    set(const float& newAxisPosition);
+            void   set(const float& newAxisPosition);
             int    updatePositionFromEncoder();
             void   initializePID();
             int    detach();
@@ -57,10 +57,7 @@
             int        _PWMread(int pin);
             void       _writeFloat(const unsigned int& addr, const float& x);
             float      _readFloat(const unsigned int& addr);
-            int        _encoderPin;
             float      _axisTarget;
-            int        _currentAngle;
-            int        _previousAngle;
             double     _timeLastMoved;
             volatile double _pidSetpoint;
             volatile double _pidInput; 
@@ -70,9 +67,8 @@
             int        _eepromAdr;
             float      _mmPerRotation = 1;
             float      _encoderSteps  = 100;
-            float      _oldSetpoint;
             bool       _disableAxisForTesting = false;
-            String     _axisName;
+            char       _axisName;
     };
 
     #endif

--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -132,9 +132,9 @@ int   setupPins(){
 
 int pinsSetup       = setupPins();
 
-Axis leftAxis (ENC, IN6, IN5, ENCODER3B, ENCODER3A, "L",  LEFT_EEPROM_ADR);
-Axis rightAxis(ENA, IN1, IN2, ENCODER1A, ENCODER1B, "R", RIGHT_EEPROM_ADR);
-Axis zAxis    (ENB, IN3, IN4, ENCODER2B, ENCODER2A, "Z",     Z_EEPROM_ADR);
+Axis leftAxis (ENC, IN6, IN5, ENCODER3B, ENCODER3A, 'L',  LEFT_EEPROM_ADR);
+Axis rightAxis(ENA, IN1, IN2, ENCODER1A, ENCODER1B, 'R', RIGHT_EEPROM_ADR);
+Axis zAxis    (ENB, IN3, IN4, ENCODER2B, ENCODER2A, 'Z',     Z_EEPROM_ADR);
 
 
 Kinematics kinematics;
@@ -207,7 +207,7 @@ void  returnPoz(const float& x, const float& y, const float& z){
     */
     
     static unsigned long lastRan = millis();
-    int                  timeout = 200;
+    unsigned int         timeout = 200;
     
     if (millis() - lastRan > timeout){
         
@@ -327,7 +327,6 @@ void pause(){
     pauseFlag = true;
     Serial.println(F("Maslow Paused"));
     
-    long timeLastPrinted = 0;
     while(1){
         
         holdPosition();
@@ -547,7 +546,7 @@ void  singleAxisMove(Axis* axis, const float& endPos, const float& MMPerMin){
     
 int   findEndOfNumber(const String& textString, const int& index){
     //Return the index of the last digit of the number beginning at the index passed in
-    int i = index;
+    unsigned int i = index;
     
     while (i < textString.length()){
         
@@ -658,11 +657,11 @@ int   G1(const String& readString, int G0orG1){
     
     if (G0orG1 == 1){
         //if this is a regular move
-        cordinatedMove(xgoto, ygoto, feedrate); //The XY move is performed
+        return cordinatedMove(xgoto, ygoto, feedrate); //The XY move is performed
     }
     else{
         //if this is a rapid move
-        cordinatedMove(xgoto, ygoto, 1000); //move the same as a regular move, but go fast
+        return cordinatedMove(xgoto, ygoto, 1000); //move the same as a regular move, but go fast
     }
 }
 
@@ -677,7 +676,6 @@ int   arc(const float& X1, const float& Y1, const float& X2, const float& Y2, co
     //compute geometry 
     float pi                     =  3.1415;
     float radius                 =  sqrt( sq(centerX - X1) + sq(centerY - Y1) ); 
-    float distanceBetweenPoints  =  sqrt( sq(  X2 - X1   ) + sq(    Y2  - Y1) );
     float circumference          =  2.0*pi*radius;
     
     float startingAngle          =  atan2(Y1 - centerY, X1 - centerX);
@@ -802,22 +800,16 @@ int   G2(const String& readString, int G2orG3){
     feedrate = constrain(feedrate, 1, MAXFEED);   //constrain the maximum feedrate, 35ipm = 900 mmpm
     
     if (G2orG3 == 2){
-        arc(X1, Y1, X2, Y2, centerX, centerY, feedrate, CLOCKWISE);
+        return arc(X1, Y1, X2, Y2, centerX, centerY, feedrate, CLOCKWISE);
     }
-    if (G2orG3 == 3){
-        arc(X1, Y1, X2, Y2, centerX, centerY, feedrate, COUNTERCLOCKWISE);
+    else {
+        return arc(X1, Y1, X2, Y2, centerX, centerY, feedrate, COUNTERCLOCKWISE);
     }
 }
 
 void  G10(const String& readString){
     /*The G10() function handles the G10 gcode which re-zeros one or all of the machine's axes.*/
-    
-    float currentXPos = xTarget;
-    float currentYPos = yTarget;
     float currentZPos = zAxis.read();
-    
-    float xgoto      = _inchesToMMConversion*extractGcodeValue(readString, 'X', currentXPos/_inchesToMMConversion);
-    float ygoto      = _inchesToMMConversion*extractGcodeValue(readString, 'Y', currentYPos/_inchesToMMConversion);
     float zgoto      = _inchesToMMConversion*extractGcodeValue(readString, 'Z', currentZPos/_inchesToMMConversion);
     
     zAxis.set(zgoto);
@@ -1085,7 +1077,6 @@ void updateMotorSettings(const String& readString){
     }
     
     //Change the motor properties in cnc_funtions if new values have been sent
-    float distPerRot = -1;
     if (gearTeeth != -1 and chainPitch != -1){
         float distPerRot = gearTeeth*chainPitch; 
         leftAxis.changePitch(distPerRot);
@@ -1115,7 +1106,7 @@ void updateMotorSettings(const String& readString){
 bool isSafeCommand(const String& readString){
     bool ret = false;
     String command = readString.substring(0, 3);
-    for(int i = 0; i < sizeof(safeCommands); i++){
+    for(byte i = 0; i < sizeof(safeCommands); i++){
        if(safeCommands[i] == command){
            ret = true;
            break;

--- a/cnc_ctrl_v1/Kinematics.cpp
+++ b/cnc_ctrl_v1/Kinematics.cpp
@@ -311,18 +311,12 @@ void  Kinematics::_MatSolv(){
 }
 
 float Kinematics::_moment(const float& Y1Plus, const float& Y2Plus, const float& Phi, const float& MSinPhi, const float& MSinPsi1, const float& MCosPsi1, const float& MSinPsi2, const float& MCosPsi2){   //computes net moment about center of mass
-    float Temp;
     float Offsetx1;
     float Offsetx2;
     float Offsety1;
     float Offsety2;
-    float Psi1;
-    float Psi2;
     float TanGamma;
     float TanLambda;
-
-    Psi1 = Theta - Phi;
-    Psi2 = Theta + Phi;
 
     Offsetx1 = h * MCosPsi1;
     Offsetx2 = h * MCosPsi2;

--- a/cnc_ctrl_v1/Kinematics.h
+++ b/cnc_ctrl_v1/Kinematics.h
@@ -65,8 +65,6 @@
 
 
             //utility variables
-            float DegPerRad = 360/(4 * atan(1));
-            unsigned long Time;
             boolean Mirror;
 
             //Calculation tolerances

--- a/cnc_ctrl_v1/MotorGearboxEncoder.cpp
+++ b/cnc_ctrl_v1/MotorGearboxEncoder.cpp
@@ -182,38 +182,14 @@ float MotorGearboxEncoder::computeSpeed(){
     return -1.0*RPM;
 }
 
-float MotorGearboxEncoder::_runningAverage(const int& newValue){
-    /*
-    
-    Compute a running average from the number passed in.
-    
-    */
-    
-    int sum = newValue + _oldValue1 + _oldValue2 + _oldValue3 + _oldValue4 + _oldValue5 + _oldValue6 + _oldValue7 + _oldValue8 + _oldValue9 + _oldValue10;
-    float runningAverage = (float(sum))/11.0;
-    
-    _oldValue10 = _oldValue9;
-    _oldValue9 = _oldValue8;
-    _oldValue8 = _oldValue7;
-    _oldValue7 = _oldValue6;
-    _oldValue6 = _oldValue5;
-    _oldValue5 = _oldValue4;
-    _oldValue4 = _oldValue3;
-    _oldValue3 = _oldValue2;
-    _oldValue2 = _oldValue1;
-    _oldValue1 = newValue;
-    
-    return runningAverage;
-}
-
-void MotorGearboxEncoder::setName(const String& newName){
+void MotorGearboxEncoder::setName(const char& newName){
     /*
     Set the name for the object
     */
     _motorName = newName;
 }
 
-String MotorGearboxEncoder::name(){
+char MotorGearboxEncoder::name(){
     /*
     Get the name for the object
     */

--- a/cnc_ctrl_v1/MotorGearboxEncoder.h
+++ b/cnc_ctrl_v1/MotorGearboxEncoder.h
@@ -31,8 +31,8 @@
             float      computeSpeed();
             void       write(const float& speed);
             void       computePID();
-            void       setName(const String& newName);
-            String     name();
+            void       setName(const char& newName);
+            char       name();
             void       initializePID();
             void       setPIDAggressiveness(float aggressiveness);
             void       setPIDValues(float KpV, float KiV, float KdV);
@@ -43,22 +43,11 @@
             double     _currentSpeed;
             double     _lastPosition;
             double     _lastTimeStamp;
-            float      _runningAverage(const int& newValue);
-            String     _motorName;
+            char       _motorName;
             double     _pidOutput;
             PID        _PIDController;
             double     _Kp=0, _Ki=0, _Kd=0;
             float      _encoderStepsToRPMScaleFactor = 7364.0;   //6*10^7 us per minute divided by 8148 steps per revolution
-            int        _oldValue1;
-            int        _oldValue2;
-            int        _oldValue3;
-            int        _oldValue4;
-            int        _oldValue5;
-            int        _oldValue6;
-            int        _oldValue7;
-            int        _oldValue8;
-            int        _oldValue9;
-            int        _oldValue10;
             float      _minimumRPM = 0.5;
     };
 

--- a/cnc_ctrl_v1/PID_v1.cpp
+++ b/cnc_ctrl_v1/PID_v1.cpp
@@ -206,14 +206,6 @@ void PID::SetControllerDirection(const int& Direction)
    controllerDirection = Direction;
 }
 
-void PID::FlushIntegrator(){
-    outputSum = 0;
-}
-
-void PID::FlipIntegrator(){
-    outputSum = -.7*outputSum;
-}
-
 /* Status Funcions*************************************************************
  * Just because you set the Kp=-1 doesn't mean it actually happened.  these
  * functions query the internal state of the PID.  they're here for display

--- a/cnc_ctrl_v1/PID_v1.h
+++ b/cnc_ctrl_v1/PID_v1.h
@@ -55,12 +55,8 @@ class PID
 										  //   once it is set in the constructor.
     void SetSampleTime(const int&);              // * sets the frequency, in Milliseconds, with which 
                                           //   the PID calculation is performed.  default is 100
-										  
-										  
-										  
-    void FlushIntegrator();               //delete the accumulated value of the integrator 
-    void FlipIntegrator();                //flip the value of the integrator term
-                                          
+
+
   //Display functions ****************************************************************
 	double GetKp();						  // These functions query the pid for interal values.
 	double GetKi();						  //  they were created mainly for the pid front-end,

--- a/cnc_ctrl_v1/RingBuffer.cpp
+++ b/cnc_ctrl_v1/RingBuffer.cpp
@@ -27,7 +27,6 @@ serial data.
 RingBuffer::RingBuffer(){
     
 }
-String temps;
 void RingBuffer::write(char letter){
     /*
     


### PR DESCRIPTION
Compiler errors were unused variables or comparison of signed and
unsigned.

Also cleaned up numerous other unused variables and functions.

Saved 2% of dynamic memory.