### PR TITLE
Improvements For Low RPM Speed Calculation

### DIFF
--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -1252,7 +1252,7 @@ void PIDTestVelocity(Axis* axis, const float start, const float stop, const floa
           if (current - print > 20000){
             // Calculate and log error on same frequency as PID interrupt
             reportedSpeed= axis->motorGearboxEncoder.cachedSpeed();
-            error =  (-1.0 * reportedSpeed) - speed;
+            error =  reportedSpeed - speed;
             print = current;
             Serial.println(error);
           }

--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -1232,9 +1232,7 @@ void PIDTestVelocity(Axis* axis, const float start, const float stop, const floa
     double startTime;
     double print = micros();
     double current = micros();
-    float lastPosition = axis->motorGearboxEncoder.encoder.read();
     float error;
-    float distMoved;
     float reportedSpeed;
     float span = stop - start;
     float speed;
@@ -1253,9 +1251,7 @@ void PIDTestVelocity(Axis* axis, const float start, const float stop, const floa
         while (startTime + 2000000 > current){
           if (current - print > 20000){
             // Calculate and log error on same frequency as PID interrupt
-            distMoved   =  axis->motorGearboxEncoder.encoder.read() - lastPosition;
-            reportedSpeed= (7364.0*distMoved)/float(current - print);  //6*10^7 us per minute, 8148 steps per revolution
-            lastPosition  = axis->motorGearboxEncoder.encoder.read();
+            reportedSpeed= axis->motorGearboxEncoder.cachedSpeed();
             error =  (-1.0 * reportedSpeed) - speed;
             print = current;
             Serial.println(error);

--- a/cnc_ctrl_v1/MotorGearboxEncoder.cpp
+++ b/cnc_ctrl_v1/MotorGearboxEncoder.cpp
@@ -172,7 +172,6 @@ float MotorGearboxEncoder::computeSpeed(){
     float currentMicros = micros();
     
     float distMoved   =  currentPosition - _lastPosition;
-    float RPM = 0;
     if (distMoved > 3 || distMoved < -3){
       
         // This dampens some of the effects of quantization without having 
@@ -184,24 +183,31 @@ float MotorGearboxEncoder::computeSpeed(){
         
         unsigned long timeElapsed =  currentMicros - _lastTimeStamp;
         //Compute the speed in RPM
-        RPM = (_encoderStepsToRPMScaleFactor*distMoved)/float(timeElapsed);
+        _RPM = (_encoderStepsToRPMScaleFactor*distMoved)/float(timeElapsed);
     
     }
     else {
         float elapsedTime = encoder.elapsedTime();
 
-        RPM = 0 ;
+        _RPM = 0 ;
         if (elapsedTime != 0){
-          RPM = _encoderStepsToRPMScaleFactor / elapsedTime;
+          _RPM = _encoderStepsToRPMScaleFactor / elapsedTime;
         }
     }
-    RPM = RPM * -1.0;
+    _RPM = _RPM * -1.0;
     
     //Store values for next time
     _lastTimeStamp = currentMicros;
     _lastPosition  = currentPosition;
     
-    return RPM;
+    return _RPM;
+}
+
+float MotorGearboxEncoder::cachedSpeed(){
+    /*
+    Returns the last result of computeSpeed
+    */
+    return _RPM;
 }
 
 void MotorGearboxEncoder::setName(const char& newName){

--- a/cnc_ctrl_v1/MotorGearboxEncoder.cpp
+++ b/cnc_ctrl_v1/MotorGearboxEncoder.cpp
@@ -173,8 +173,15 @@ float MotorGearboxEncoder::computeSpeed(){
     
     float distMoved   =  currentPosition - _lastPosition;
     float RPM = 0;
-    if (distMoved > 3 || distMoved < -3){ 
-    
+    if (distMoved > 3 || distMoved < -3){
+      
+        // This dampens some of the effects of quantization without having 
+        // a big effect on other changes
+        float saveDistMoved = distMoved;
+        if (distMoved - _lastDistMoved <= -1){ distMoved + .5;}
+        else if (distMoved - _lastDistMoved >= 1){distMoved - .5;}
+        _lastDistMoved = saveDistMoved;
+        
         unsigned long timeElapsed =  currentMicros - _lastTimeStamp;
         //Compute the speed in RPM
         RPM = (_encoderStepsToRPMScaleFactor*distMoved)/float(timeElapsed);
@@ -193,12 +200,6 @@ float MotorGearboxEncoder::computeSpeed(){
     //Store values for next time
     _lastTimeStamp = currentMicros;
     _lastPosition  = currentPosition;
-    _lastRPM = RPM;
-    
-     // This dampens some of the effects of quantization without having 
-     // a big effect on other changes 
-     if (RPM - _lastRPM < -1){ RPM + .5;}
-     else if (RPM - _lastRPM > 1){RPM - .5;}
     
     return RPM;
 }

--- a/cnc_ctrl_v1/MotorGearboxEncoder.cpp
+++ b/cnc_ctrl_v1/MotorGearboxEncoder.cpp
@@ -60,57 +60,10 @@ void  MotorGearboxEncoder::computePID(){
     /*
     Recompute the speed control PID loop and command the motor to move.
     */
-    _currentSpeed = computeSpeed();
-    
-    /*if (millis() < 8000){
-        _targetSpeed = 0;
-    }
-    else if (millis() < 12000){
-        _targetSpeed = 10;
-    }
-    else if (millis() < 18000){
-         _targetSpeed = 0;
-    }
-    else if(millis() < 24000){
-        _targetSpeed = float((millis() - 18000))/400.0;
-    }
-    else if (millis() < 32000){
-        _targetSpeed = 0;
-    }
-    else if (millis() < 40000){
-        _targetSpeed = 10;
-    }
-    else if (millis() < 48000){
-        _targetSpeed = 0;
-    }
-    else if (millis() < 56000){
-        _targetSpeed = -10;
-    }
-    else if (millis() < 64000){
-        _targetSpeed = 0;
-    }
-    else if (millis() < 72000){
-        _targetSpeed = 10;
-    }
-    else if (millis() < 80000){
-        _targetSpeed = 0;
-    }
-    else{
-        _targetSpeed = 0;
-    }*/
-    
-    // Between these speeds the motor is incapable of turning and it only
-    // causes the Iterm in the PID calculation to wind up
+    _currentSpeed = _computeSpeed();
 
     _PIDController.Compute();
-        
-    /*if(_motorName[0] == 'R'){
-        //Serial.print(_currentSpeed);
-        //Serial.print(" ");
-        Serial.println(_targetSpeed);
-    }*/
-    
-    //motor.attach();
+
     motor.write(_pidOutput);
 }
 
@@ -161,10 +114,12 @@ void MotorGearboxEncoder::setEncoderResolution(float resolution){
     
 }
 
-float MotorGearboxEncoder::computeSpeed(){
+float MotorGearboxEncoder::_computeSpeed(){
     /*
     
     Returns the motors speed in RPM since the last time this function was called
+    should only be called by the PID process otherwise we are calculating the
+    distance moved over a varying amount of time.
     
     */
     

--- a/cnc_ctrl_v1/MotorGearboxEncoder.cpp
+++ b/cnc_ctrl_v1/MotorGearboxEncoder.cpp
@@ -188,12 +188,19 @@ float MotorGearboxEncoder::computeSpeed(){
           RPM = _encoderStepsToRPMScaleFactor / elapsedTime;
         }
     }
+    RPM = RPM * -1.0;
     
     //Store values for next time
     _lastTimeStamp = currentMicros;
     _lastPosition  = currentPosition;
+    _lastRPM = RPM;
     
-    return -1.0*RPM;
+     // This dampens some of the effects of quantization without having 
+     // a big effect on other changes 
+     if (RPM - _lastRPM < -1){ RPM + .5;}
+     else if (RPM - _lastRPM > 1){RPM - .5;}
+    
+    return RPM;
 }
 
 void MotorGearboxEncoder::setName(const char& newName){

--- a/cnc_ctrl_v1/MotorGearboxEncoder.h
+++ b/cnc_ctrl_v1/MotorGearboxEncoder.h
@@ -43,7 +43,8 @@
             double     _currentSpeed;
             volatile double     _lastPosition;
             volatile double     _lastTimeStamp;
-            char     _motorName;
+            float               _lastRPM;
+            char       _motorName;
             double     _pidOutput;
             PID        _PIDController;
             double     _Kp=0, _Ki=0, _Kd=0;

--- a/cnc_ctrl_v1/MotorGearboxEncoder.h
+++ b/cnc_ctrl_v1/MotorGearboxEncoder.h
@@ -43,7 +43,7 @@
             double     _currentSpeed;
             volatile double     _lastPosition;
             volatile double     _lastTimeStamp;
-            float               _lastRPM;
+            float               _lastDistMoved;
             char       _motorName;
             double     _pidOutput;
             PID        _PIDController;

--- a/cnc_ctrl_v1/MotorGearboxEncoder.h
+++ b/cnc_ctrl_v1/MotorGearboxEncoder.h
@@ -28,7 +28,6 @@
             MotorGearboxEncoder(const int& pwmPin, const int& directionPin1, const int& directionPin2, const int& encoderPin1, const int& encoderPin2);
             Encoder    encoder;
             Motor      motor;
-            float      computeSpeed();
             float      cachedSpeed();
             void       write(const float& speed);
             void       computePID();
@@ -51,6 +50,7 @@
             PID        _PIDController;
             double     _Kp=0, _Ki=0, _Kd=0;
             float      _encoderStepsToRPMScaleFactor = 7364.0;   //6*10^7 us per minute divided by 8148 steps per revolution
+            float      _computeSpeed();
     };
 
     #endif

--- a/cnc_ctrl_v1/MotorGearboxEncoder.h
+++ b/cnc_ctrl_v1/MotorGearboxEncoder.h
@@ -41,14 +41,13 @@
         private:
             double     _targetSpeed;
             double     _currentSpeed;
-            double     _lastPosition;
-            double     _lastTimeStamp;
-            char       _motorName;
+            volatile double     _lastPosition;
+            volatile double     _lastTimeStamp;
+            char     _motorName;
             double     _pidOutput;
             PID        _PIDController;
             double     _Kp=0, _Ki=0, _Kd=0;
             float      _encoderStepsToRPMScaleFactor = 7364.0;   //6*10^7 us per minute divided by 8148 steps per revolution
-            float      _minimumRPM = 0.5;
     };
 
     #endif

--- a/cnc_ctrl_v1/MotorGearboxEncoder.h
+++ b/cnc_ctrl_v1/MotorGearboxEncoder.h
@@ -29,6 +29,7 @@
             Encoder    encoder;
             Motor      motor;
             float      computeSpeed();
+            float      cachedSpeed();
             void       write(const float& speed);
             void       computePID();
             void       setName(const char& newName);
@@ -44,6 +45,7 @@
             volatile double     _lastPosition;
             volatile double     _lastTimeStamp;
             float               _lastDistMoved;
+            float               _RPM;
             char       _motorName;
             double     _pidOutput;
             PID        _PIDController;


### PR DESCRIPTION
- Adds an elapsedtime attribute to the encoder which returns the number of microseconds between the last two encoder steps, this allows for more accurate resolution of the RPM at very low speeds.
- Dampen some of the quantization that occurs when using steps to calculate RPM
- Change ComputeSpeed to private function since calling it outside of the PID calculation causes the speed to be calculated on less than a full loop.
- Add CachedSpeed function to obtain the RPM last returned by ComputeSpeed, useful at least for PIDVelocity tuning function.