### PR TITLE
Configurable Loop Timing; Improved Movement Loop Timing; and Debugging

### DIFF
--- a/cnc_ctrl_v1/Axis.cpp
+++ b/cnc_ctrl_v1/Axis.cpp
@@ -58,7 +58,7 @@ void   Axis::loadPositionFromMemory(){
 void   Axis::initializePID(){
     _pidController.SetMode(AUTOMATIC);
     _pidController.SetOutputLimits(-20, 20);
-    _pidController.SetSampleTime(10);
+    _pidController.SetSampleTime(LOOPINTERVAL / 1000);
 }
 
 void    Axis::write(const float& targetPosition){

--- a/cnc_ctrl_v1/Axis.cpp
+++ b/cnc_ctrl_v1/Axis.cpp
@@ -23,9 +23,9 @@
 #define SIZEOFFLOAT      4
 #define SIZEOFLINSEG    17
 
-Axis::Axis(const int& pwmPin, const int& directionPin1, const int& directionPin2, const int& encoderPin1, const int& encoderPin2, const char& axisName, const int& eepromAdr)
+Axis::Axis(const int& pwmPin, const int& directionPin1, const int& directionPin2, const int& encoderPin1, const int& encoderPin2, const char& axisName, const int& eepromAdr, const unsigned long& loopInterval)
 :
-motorGearboxEncoder(pwmPin, directionPin1, directionPin2, encoderPin1, encoderPin2)
+motorGearboxEncoder(pwmPin, directionPin1, directionPin2, encoderPin1, encoderPin2, loopInterval)
 {
     
     _pidController.setup(&_pidInput, &_pidOutput, &_pidSetpoint, 0, 0, 0, P_ON_E, REVERSE);
@@ -34,7 +34,7 @@ motorGearboxEncoder(pwmPin, directionPin1, directionPin2, encoderPin1, encoderPi
     _axisName     = axisName;
     _eepromAdr    = eepromAdr;
     
-    initializePID();
+    initializePID(loopInterval);
     
     motorGearboxEncoder.setName(_axisName);
 }
@@ -55,10 +55,10 @@ void   Axis::loadPositionFromMemory(){
         
 }
 
-void   Axis::initializePID(){
+void   Axis::initializePID(const unsigned long& loopInterval){
     _pidController.SetMode(AUTOMATIC);
     _pidController.SetOutputLimits(-20, 20);
-    _pidController.SetSampleTime(LOOPINTERVAL / 1000);
+    _pidController.SetSampleTime( loopInterval / 1000);
 }
 
 void    Axis::write(const float& targetPosition){

--- a/cnc_ctrl_v1/Axis.h
+++ b/cnc_ctrl_v1/Axis.h
@@ -22,16 +22,15 @@
     #include "PID_v1.h"
     #include <EEPROM.h>
     #include "MotorGearboxEncoder.h"
-    
 
     class Axis{
         public:
-            Axis(const int& pwmPin, const int& directionPin1, const int& directionPin2, const int& encoderPin1, const int& encoderPin2, const char& axisName, const int& eepromAdr);
+            Axis(const int& pwmPin, const int& directionPin1, const int& directionPin2, const int& encoderPin1, const int& encoderPin2, const char& axisName, const int& eepromAdr, const unsigned long& loopInterval);
             void   write(const float& targetPosition);
             float  read();
             void   set(const float& newAxisPosition);
             int    updatePositionFromEncoder();
-            void   initializePID();
+            void   initializePID(const unsigned long& loopInterval);
             int    detach();
             int    attach();
             void   hold();

--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -156,7 +156,7 @@ bool  zEncoderStepsChanged  =  false;
 volatile bool  movementUpdated  =  false;
 
 // Global variables for misloop tracking
-#if misloopDebug > 1              
+#if misloopDebug > 0
 volatile bool  inMovementLoop   =  false;
 volatile bool  movementFail     =  false;
 #endif
@@ -416,7 +416,7 @@ float computeStepSize(const float& MMPerMin){
 }
  
 void movementUpdate(){
-  #if misloopDebug > 1  
+  #if misloopDebug > 0
   if (movementFail){
     Serial.println("Movement loop failed to complete before interrupt.");
     movementFail = false;
@@ -479,7 +479,7 @@ int   cordinatedMove(const float& xEnd, const float& yEnd, const float& zEnd, fl
     
     while(numberOfStepsTaken < finalNumberOfSteps){
       
-        #if misloopDebug > 1   
+        #if misloopDebug > 0
         inMovementLoop = true;
         #endif
         //if last movment was performed start the next
@@ -533,7 +533,7 @@ int   cordinatedMove(const float& xEnd, const float& yEnd, const float& zEnd, fl
             }
         }
     }
-    #if misloopDebug > 1 
+    #if misloopDebug > 0
     inMovementLoop = false;
     #endif
     
@@ -574,8 +574,7 @@ void  singleAxisMove(Axis* axis, const float& endPos, const float& MMPerMin){
     axis->attach();
     
     float whereAxisShouldBeAtThisStep = startingPos;
-    
-    #if misloopDebug > 1 
+    #if misloopDebug > 0
     inMovementLoop = true;
     #endif
     while(numberOfStepsTaken < finalNumberOfSteps){
@@ -603,7 +602,7 @@ void  singleAxisMove(Axis* axis, const float& endPos, const float& MMPerMin){
             return;
         }
     }
-    #if misloopDebug > 1 
+    #if misloopDebug > 0
     inMovementLoop = false;
     #endif
     
@@ -787,7 +786,7 @@ int   arc(const float& X1, const float& Y1, const float& X2, const float& Y2, co
     rightAxis.attach();
     
     while(numberOfStepsTaken < abs(finalNumberOfSteps)){
-        #if misloopDebug > 1 
+        #if misloopDebug > 0
         inMovementLoop = true;
         #endif
         
@@ -829,7 +828,7 @@ int   arc(const float& X1, const float& Y1, const float& X2, const float& Y2, co
             }
         }
     }
-    #if misloopDebug > 1 
+    #if misloopDebug > 0
     inMovementLoop = false;
     #endif
     

--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -43,7 +43,7 @@ bool zAxisAttached = false;
 #define INCHES      25.4
 #define MAXFEED     900      //The maximum allowable feedrate in mm/min
 #define MAXZROTMIN  12.60    // the maximum z rotations per minute
-
+#define LOOPINTERVAL 10.00
 
 int ENCODER1A;
 int ENCODER1B;
@@ -376,13 +376,7 @@ float calculateDelay(const float& stepSizeMM, const float& feedrateMMPerMin){
     Calculate the time delay between each step for a given feedrate
     */
     
-    #define MINUTEINMS 60000.0
-    
-    // derivation: ms / step = 1 min in ms / dist in one min
-    
-    float msPerStep = (stepSizeMM*MINUTEINMS)/feedrateMMPerMin;
-    
-    return msPerStep;
+    return LOOPINTERVAL;
 }
 
 float calculateFeedrate(const float& stepSizeMM, const float& msPerStep){
@@ -407,7 +401,7 @@ float computeStepSize(const float& MMPerMin){
     
     */
     
-    return .0001575*MMPerMin; //value found empirically by running loop until there were not spare cycles
+    return (LOOPINTERVAL/60000)*MMPerMin;
 }
 
 int   cordinatedMove(const float& xEnd, const float& yEnd, const float& zEnd, float MMPerMin){
@@ -463,10 +457,7 @@ int   cordinatedMove(const float& xEnd, const float& yEnd, const float& zEnd, fl
     
     while(numberOfStepsTaken < finalNumberOfSteps){
         //if enough time has passed to take the next step
-        if (millis() - beginingOfLastStep > delayTime){
-          
-            //reset the counter 
-            beginingOfLastStep          = millis();
+        if (millis() - beginingOfLoop > (LOOPINTERVAL*numberOfStepsTaken)) {
               
             //find the target point for this step
             float whereXShouldBeAtThisStep = xStartingLocation + (numberOfStepsTaken*xStepSize);
@@ -752,8 +743,6 @@ int   arc(const float& X1, const float& Y1, const float& X2, const float& Y2, co
     
     float aChainLength;
     float bChainLength;
-
-    float delayTime = calculateDelay(stepSizeMM, MMPerMin);
     
     //attach the axes
     leftAxis.attach();
@@ -764,10 +753,7 @@ int   arc(const float& X1, const float& Y1, const float& X2, const float& Y2, co
     while(numberOfStepsTaken < abs(finalNumberOfSteps)){
         
         //if enough time has passed to take the next step
-        if (millis() - beginingOfLastStep > delayTime){
-            
-            //reset the counter 
-            beginingOfLastStep          = millis();
+        if (millis() - beginingOfLoop > (numberOfStepsTaken * LOOPINTERVAL)){
             
             degreeComplete = float(numberOfStepsTaken)/float(finalNumberOfSteps);
             

--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -134,9 +134,9 @@ int   setupPins(){
 
 int pinsSetup       = setupPins();
 
-Axis leftAxis (ENC, IN6, IN5, ENCODER3B, ENCODER3A, 'L',  LEFT_EEPROM_ADR);
-Axis rightAxis(ENA, IN1, IN2, ENCODER1A, ENCODER1B, 'R', RIGHT_EEPROM_ADR);
-Axis zAxis    (ENB, IN3, IN4, ENCODER2B, ENCODER2A, 'Z',     Z_EEPROM_ADR);
+Axis leftAxis (ENC, IN6, IN5, ENCODER3B, ENCODER3A, 'L',  LEFT_EEPROM_ADR, LOOPINTERVAL);
+Axis rightAxis(ENA, IN1, IN2, ENCODER1A, ENCODER1B, 'R', RIGHT_EEPROM_ADR, LOOPINTERVAL);
+Axis zAxis    (ENB, IN3, IN4, ENCODER2B, ENCODER2A, 'Z',     Z_EEPROM_ADR, LOOPINTERVAL);
 
 
 Kinematics kinematics;

--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -453,7 +453,7 @@ int   cordinatedMove(const float& xEnd, const float& yEnd, const float& zEnd, fl
     float bChainLength;
     float zPosition                   = zStartingLocation;
     long   numberOfStepsTaken         =  0;
-    unsigned long beginingOfLastStep = millis() - delayTime;
+    unsigned long beginingOfLoop = millis();
     
     while(numberOfStepsTaken < finalNumberOfSteps){
         //if enough time has passed to take the next step
@@ -527,24 +527,22 @@ void  singleAxisMove(Axis* axis, const float& endPos, const float& MMPerMin){
     
     float direction            = moveDist/abs(moveDist); //determine the direction of the move
     
-    float stepSizeMM           = 0.01;                    //step size in mm
+    float stepSizeMM           = computeStepSize(MMPerMin);                    //step size in mm
 
     //the argument to abs should only be a variable -- splitting calc into 2 lines
     long finalNumberOfSteps    = abs(moveDist/stepSizeMM);      //number of steps taken in move
     finalNumberOfSteps = abs(finalNumberOfSteps);
-
-    float delayTime = calculateDelay(stepSizeMM, MMPerMin);
     
     long numberOfStepsTaken    = 0;
     
     //attach the axis we want to move
     axis->attach();
     
-    unsigned long beginingOfLastStep = millis() - delayTime;
+    unsigned long beginingOfLastStep = millis() - LOOPINTERVAL;
     float whereAxisShouldBeAtThisStep;
     
     while(numberOfStepsTaken < finalNumberOfSteps){
-        if (millis() - beginingOfLastStep > delayTime){
+        if (millis() - beginingOfLastStep > LOOPINTERVAL){
           beginingOfLastStep = millis();
           //find the target point for this step
           whereAxisShouldBeAtThisStep = startingPos + numberOfStepsTaken*stepSizeMM*direction;
@@ -748,7 +746,7 @@ int   arc(const float& X1, const float& Y1, const float& X2, const float& Y2, co
     leftAxis.attach();
     rightAxis.attach();
     
-    unsigned long  beginingOfLastStep  = millis() - delayTime;
+    unsigned long  beginingOfLoop  = millis();
     
     while(numberOfStepsTaken < abs(finalNumberOfSteps)){
         
@@ -902,17 +900,15 @@ void  G38(const String& readString) {
         long finalNumberOfSteps    = moveDist / stepSizeMM;    //number of steps taken in move
         finalNumberOfSteps = abs(finalNumberOfSteps);
 
-        float delayTime = calculateDelay(stepSizeMM, MMPerMin);
-
         long numberOfStepsTaken    = 0;
-        unsigned long  beginingOfLastStep = millis() - delayTime;
+        unsigned long  beginingOfLastStep = millis() - LOOPINTERVAL;
         float whereAxisShouldBeAtThisStep;
   
         axis->attach();
         //  zAxis->attach();
 
         while (numberOfStepsTaken < finalNumberOfSteps) {
-          if (millis() - beginingOfLastStep > delayTime){
+          if (millis() - beginingOfLastStep > LOOPINTERVAL){
               //reset the counter
               beginingOfLastStep          = millis();
 

--- a/cnc_ctrl_v1/MotorGearboxEncoder.cpp
+++ b/cnc_ctrl_v1/MotorGearboxEncoder.cpp
@@ -24,7 +24,7 @@ to be a drop in replacement for a continuous rotation servo.
 #include "Arduino.h"
 #include "MotorGearboxEncoder.h"
 
-MotorGearboxEncoder::MotorGearboxEncoder(const int& pwmPin, const int& directionPin1, const int& directionPin2, const int& encoderPin1, const int& encoderPin2)
+MotorGearboxEncoder::MotorGearboxEncoder(const int& pwmPin, const int& directionPin1, const int& directionPin2, const int& encoderPin1, const int& encoderPin2, const unsigned long& loopInterval)
 :
 encoder(encoderPin1,encoderPin2)
 {
@@ -35,7 +35,7 @@ encoder(encoderPin1,encoderPin2)
     
     //initialize the PID
     _PIDController.setup(&_currentSpeed, &_pidOutput, &_targetSpeed, _Kp, _Ki, _Kd, P_ON_E, DIRECT);
-    initializePID();
+    initializePID(loopInterval);
     
     
 }
@@ -49,11 +49,11 @@ void  MotorGearboxEncoder::write(const float& speed){
     
 }
 
-void   MotorGearboxEncoder::initializePID(){
+void   MotorGearboxEncoder::initializePID(const unsigned long& loopInterval){
     //setup positive PID controller
     _PIDController.SetMode(AUTOMATIC);
     _PIDController.SetOutputLimits(-255, 255);
-    _PIDController.SetSampleTime(LOOPINTERVAL / 1000);
+    _PIDController.SetSampleTime(loopInterval / 1000);
 }
 
 void  MotorGearboxEncoder::computePID(){

--- a/cnc_ctrl_v1/MotorGearboxEncoder.cpp
+++ b/cnc_ctrl_v1/MotorGearboxEncoder.cpp
@@ -53,7 +53,7 @@ void   MotorGearboxEncoder::initializePID(){
     //setup positive PID controller
     _PIDController.SetMode(AUTOMATIC);
     _PIDController.SetOutputLimits(-255, 255);
-    _PIDController.SetSampleTime(10);
+    _PIDController.SetSampleTime(LOOPINTERVAL / 1000);
 }
 
 void  MotorGearboxEncoder::computePID(){

--- a/cnc_ctrl_v1/MotorGearboxEncoder.h
+++ b/cnc_ctrl_v1/MotorGearboxEncoder.h
@@ -25,7 +25,7 @@
     
     class MotorGearboxEncoder{
         public:
-            MotorGearboxEncoder(const int& pwmPin, const int& directionPin1, const int& directionPin2, const int& encoderPin1, const int& encoderPin2);
+            MotorGearboxEncoder(const int& pwmPin, const int& directionPin1, const int& directionPin2, const int& encoderPin1, const int& encoderPin2, const unsigned long& loopInterval);
             Encoder    encoder;
             Motor      motor;
             float      cachedSpeed();
@@ -33,7 +33,7 @@
             void       computePID();
             void       setName(const char& newName);
             char       name();
-            void       initializePID();
+            void       initializePID(const unsigned long& loopInterval);
             void       setPIDAggressiveness(float aggressiveness);
             void       setPIDValues(float KpV, float KiV, float KdV);
             void       setEncoderResolution(float resolution);

--- a/cnc_ctrl_v1/cnc_ctrl_v1.ino
+++ b/cnc_ctrl_v1/cnc_ctrl_v1.ino
@@ -31,8 +31,7 @@ void setup(){
     Serial.println(F("ready"));
     _signalReady();
     
-    
-    Timer1.initialize(LOOPINTERVAL*1000);
+    Timer1.initialize(LOOPINTERVAL);
     Timer1.attachInterrupt(runsOnATimer);
     
     Serial.println(F("Grbl v1.00"));

--- a/cnc_ctrl_v1/cnc_ctrl_v1.ino
+++ b/cnc_ctrl_v1/cnc_ctrl_v1.ino
@@ -32,7 +32,7 @@ void setup(){
     _signalReady();
     
     
-    Timer1.initialize(10000);
+    Timer1.initialize(LOOPINTERVAL*1000);
     Timer1.attachInterrupt(runsOnATimer);
     
     Serial.println(F("Grbl v1.00"));

--- a/cnc_ctrl_v1/cnc_ctrl_v1.ino
+++ b/cnc_ctrl_v1/cnc_ctrl_v1.ino
@@ -39,6 +39,12 @@ void setup(){
 }
 
 void runsOnATimer(){
+    #if misloopDebug > 1 
+    if (inMovementLoop && !movementUpdated){
+        movementFail = true;
+    }
+    #endif
+    movementUpdated = false;
     leftAxis.computePID();
     rightAxis.computePID();
     zAxis.computePID();

--- a/cnc_ctrl_v1/cnc_ctrl_v1.ino
+++ b/cnc_ctrl_v1/cnc_ctrl_v1.ino
@@ -39,7 +39,7 @@ void setup(){
 }
 
 void runsOnATimer(){
-    #if misloopDebug > 1 
+    #if misloopDebug > 0
     if (inMovementLoop && !movementUpdated){
         movementFail = true;
     }


### PR DESCRIPTION
Adds a compiler variable LOOPINTERVAL that sets the number of microseconds between each PID.  All places throughout the code that rely on the loop timing for any calculations are adjusted appropriately. 
 This allows an advanced user to test out a higher PID frequency.  

Also adds a compiler variable misloopDebug, that when set to 1 (defaults to 0) will warn the user whenever the movement loop fails to complete before being interrupted by the PID loop.  This is useful for testing and finding your fastest LOOPINTERVAL setting.

Please be careful increasing the PID frequency, I am concerned based on subjective testing that there may be a heat dissipation issue when used at high frequencies.

The above changes will not affect a regular compile of the Firmware and but require a developer to alter the values before compiling to cause any change from how this function now.

Finally, I have removed the concept of a timer in the movement loop entirely.  Instead, each loop waits until the PID loop processes the previously sent command before sending the next command.  This is much simpler and less error prone.