### PR TITLE
Fix Error in Quantization Buffer; Allow RPM to Approach 0

### DIFF
--- a/cnc_ctrl_v1/Encoder.h
+++ b/cnc_ctrl_v1/Encoder.h
@@ -125,6 +125,17 @@ public:
 		interrupts();
 		return ret;
 	}
+	inline int32_t lastStepTime() {
+		if (interrupts_in_use < 2) {
+			noInterrupts();
+			update(&encoder);
+		} else {
+			noInterrupts();
+		}
+		int32_t ret = encoder.lastTime;
+		interrupts();
+		return ret;
+	}
 	inline void write(int32_t p) {
 		noInterrupts();
 		encoder.position = p;

--- a/cnc_ctrl_v1/MotorGearboxEncoder.cpp
+++ b/cnc_ctrl_v1/MotorGearboxEncoder.cpp
@@ -132,8 +132,8 @@ float MotorGearboxEncoder::_computeSpeed(){
         // This dampens some of the effects of quantization without having 
         // a big effect on other changes
         float saveDistMoved = distMoved;
-        if (distMoved - _lastDistMoved <= -1){ distMoved + .5;}
-        else if (distMoved - _lastDistMoved >= 1){distMoved - .5;}
+        if (distMoved - _lastDistMoved <= -1){ distMoved += .5;}
+        else if (distMoved - _lastDistMoved >= 1){distMoved -= .5;}
         _lastDistMoved = saveDistMoved;
         
         unsigned long timeElapsed =  currentMicros - _lastTimeStamp;
@@ -143,6 +143,16 @@ float MotorGearboxEncoder::_computeSpeed(){
     }
     else {
         float elapsedTime = encoder.elapsedTime();
+        float lastTime = micros() - encoder.lastStepTime();  // no direction associated with this
+        if (lastTime > abs(elapsedTime)) {
+            // This allows the RPM to approach 0
+            if (elapsedTime < 0){
+                elapsedTime = -lastTime;
+            }
+            else {
+                elapsedTime = lastTime;
+            }
+        };
 
         _RPM = 0 ;
         if (elapsedTime != 0){


### PR DESCRIPTION
Silly typo in quantization buffer prevented it from doing anything.

If amount of time since last seen encoder step is greater than time
between last encoder steps, then use the time last seen to calculate
speed.  This allows us to at least see speeds approaching 0.  With
elapsedtime only, RPMs would rarely approach 0.