### PR TITLE
Avoid divide by zero error in coordinated move()

### DIFF
--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -446,7 +446,7 @@ int   cordinatedMove(const float& xEnd, const float& yEnd, const float& zEnd, fl
     //compute feed details
     MMPerMin = constrain(MMPerMin, 1, MAXFEED);   //constrain the maximum feedrate, 35ipm = 900 mmpm
     float  stepSizeMM           = computeStepSize(MMPerMin);
-    long   finalNumberOfSteps   = abs(distanceToMoveInMM/stepSizeMM);
+    float   finalNumberOfSteps  = abs(distanceToMoveInMM/stepSizeMM);
     float  delayTime            = calculateDelay(stepSizeMM, MMPerMin);
     float  zFeedrate            = calculateFeedrate((zDistanceToMoveInMM/finalNumberOfSteps), delayTime);
     

--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -425,7 +425,7 @@ void movementUpdate(){
   movementUpdated = true;
 }
 
-int   cordinatedMove(const float& xEnd, const float& yEnd, const float& zEnd, float MMPerMin){
+int   coordinatedMove(const float& xEnd, const float& yEnd, const float& zEnd, float MMPerMin){
     
     /*The move() function moves the tool in a straight line to the position (xEnd, yEnd) at 
     the speed moveSpeed. Movements are correlated so that regardless of the distances moved in each 
@@ -723,11 +723,11 @@ int   G1(const String& readString, int G0orG1){
     
     if (G0orG1 == 1){
         //if this is a regular move
-        cordinatedMove(xgoto, ygoto, zgoto, feedrate); //The XY move is performed
+        coordinatedMove(xgoto, ygoto, zgoto, feedrate); //The XY move is performed
     }
     else{
         //if this is a rapid move
-        cordinatedMove(xgoto, ygoto, zgoto, 1000); //move the same as a regular move, but go fast
+        coordinatedMove(xgoto, ygoto, zgoto, 1000); //move the same as a regular move, but go fast
     }
 }
 


### PR DESCRIPTION
Division of two floats can be truncated to zero if cast as a long. finalNmberOfSteps is used as a denominator in subsequent calculations.
This corrects issue #321.