### PR TITLE
Halt on serial buffer overflow

### DIFF
--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -213,6 +213,9 @@ int   nextTool              =  0;         //Stores the value of the next tool nu
 float xTarget = 0;
 float yTarget = 0;
 
+
+bool checkForStopCommand();
+
 bool machineReady(){
   bool ret = false;
   if (rcvdMotorSettings && rcvdKinematicSettings){
@@ -333,7 +336,11 @@ void readSerialCommands(){
                 pauseFlag = false;
             }
             else{
-                ringBuffer.write(c); //gets one byte from serial buffer, writes it to the internal ring buffer
+                int bufferOverflow = ringBuffer.write(c); //gets one byte from serial buffer, writes it to the internal ring buffer
+                if (bufferOverflow != 0) {
+                  stopFlag = true;
+                  checkForStopCommand();
+                }
             }
         }
         #if defined (verboseDebug) && verboseDebug > 1              

--- a/cnc_ctrl_v1/RingBuffer.cpp
+++ b/cnc_ctrl_v1/RingBuffer.cpp
@@ -27,15 +27,18 @@ serial data.
 RingBuffer::RingBuffer(){
     
 }
-void RingBuffer::write(char letter){
+int RingBuffer::write(char letter){
     /*
     
     Write one character into the ring buffer.
+    Return 0 on success
+    Return 1 on buffer overflow
     
     */
     if (letter != '?'){                    //ignore question marks because grbl sends them all the time
         _buffer[_endOfString] = letter;
-        _incrementEnd();
+        int bufferOverflow = _incrementEnd();
+        return bufferOverflow;
     }
 }
 
@@ -148,7 +151,7 @@ void RingBuffer::_incrementBeginning(){
         _beginningOfString = (_beginningOfString + 1) % BUFFERSIZE;    //move the beginning up one and wrap to zero based upon BUFFERSIZE
 }
 
-void RingBuffer::_incrementEnd(){
+int RingBuffer::_incrementEnd(){
     /*
     
     Increment the pointer to the end of the ring buffer by one.
@@ -157,9 +160,11 @@ void RingBuffer::_incrementEnd(){
     if ( spaceAvailable() == 0 ) {
         Serial.println(F("Buffer overflow!"));
         print();    // print buffer info and contents
+        return 1;
         }
     else
         _endOfString = (_endOfString+1) % BUFFERSIZE;
+        return 0;
  }
 
 void RingBuffer::_incrementVariable(int* variable){

--- a/cnc_ctrl_v1/RingBuffer.h
+++ b/cnc_ctrl_v1/RingBuffer.h
@@ -25,7 +25,7 @@
     class RingBuffer{
         public:
             RingBuffer();
-            void  write(char letter);
+            int   write(char letter);
             void  print();
             char  read();
             int   length();
@@ -36,7 +36,7 @@
             
         private:
             void _incrementBeginning();
-            void _incrementEnd();
+            int  _incrementEnd();
             void _incrementVariable(int* variable);
             int  _beginningOfString = 0;             //points to the first valid character which can be read
             int  _endOfString       = 0;             //points to the first open space which can be written


### PR DESCRIPTION
RingBuffer.::write() will return a value to indicate the buffer overrun, so the logic in readSerialCommands() can trigger an immediate stop in the same way other portions of CNC_Functions.h do:
stopFlag = true;
checkForStopCommand();
This will have the same effect as using the ‘Stop’ button in GC, but won't need to go through the serial channel to take effect.
This seems like a minimal change that uses the existing methods and routines…

To test this, create a macro in GC with more than RingBuffer::BUFFERSIZE (currently 128) characters...