### PR TITLE
Clicking Stop, Stops the Axis Where it is Not Where it Should Be

### DIFF
--- a/cnc_ctrl_v1/Axis.cpp
+++ b/cnc_ctrl_v1/Axis.cpp
@@ -242,6 +242,19 @@ void   Axis::endMove(const float& finalTarget){
     
 }
 
+void   Axis::stop(){
+    /*
+
+    Immediately stop and detach the axis, no matter where it is
+
+    */
+
+    _timeLastMoved = millis();
+    _axisTarget    = read();
+    detach();
+
+}
+
 void   Axis::wipeEEPROM(){
     /*
     

--- a/cnc_ctrl_v1/Axis.cpp
+++ b/cnc_ctrl_v1/Axis.cpp
@@ -245,13 +245,13 @@ void   Axis::endMove(const float& finalTarget){
 void   Axis::stop(){
     /*
 
-    Immediately stop and detach the axis, no matter where it is
+    Immediately stop the axis where it is, not where it should be
 
     */
 
     _timeLastMoved = millis();
-    _axisTarget    = read();
-    detach();
+    _axisTarget    = read()/_mmPerRotation;
+    _pidSetpoint   = read()/_mmPerRotation;
 
 }
 

--- a/cnc_ctrl_v1/Axis.h
+++ b/cnc_ctrl_v1/Axis.h
@@ -35,6 +35,7 @@
             int    attach();
             void   hold();
             void   endMove(const float& finalTarget);
+            void   stop();
             float  target();
             float  error();
             float  setpoint();


### PR DESCRIPTION
Fixes #293 

This adds a stop function to Axis.  Calling it stops the motor where it is, not where it should be.  This should ensure that even when things have gone wrong, there will not be a 2 second lag in stopping the axis.

Also unifies the checkforstopcommand function, so that its actions are consistent whenever a stop command is encountered.

PR #333 should be merged first, otherwise there will be an oddity in stopping the zaxis.