### PR TITLE
Additive Velocity Control; PID Logging; Voltage Logging

### DIFF
--- a/cnc_ctrl_v1/Axis.cpp
+++ b/cnc_ctrl_v1/Axis.cpp
@@ -313,3 +313,6 @@ void   Axis::test(){
     motorGearboxEncoder.motor.directWrite(0);
     Serial.print(F("<Idle,MPos:0,0,0,WPos:0.000,0.000,0.000>"));
 }
+
+double  Axis::pidInput(){ return _pidInput*_mmPerRotation;}
+double  Axis::pidOutput(){ return _pidOutput;}

--- a/cnc_ctrl_v1/Axis.h
+++ b/cnc_ctrl_v1/Axis.h
@@ -52,6 +52,8 @@
             void   setPIDValues(float Kp, float Ki, float Kd, float propWeight, float KpV, float KiV, float KdV);
             void   loadPositionFromMemory();
             String     getPIDString();
+            double     pidInput();
+            double     pidOutput();
             
         private:
             int        _PWMread(int pin);

--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -1611,7 +1611,7 @@ void  executeBcodeLine(const String& gcodeLine){
         return;
     }
     
-    if(gcodeLine.substring(0, 3) == "B15"){
+    if(gcodeLine.substring(0, 3) == "B16"){
         //Incrementally tests voltages to see what RPMs they produce
         float  left       = extractGcodeValue(gcodeLine, 'L', 0);
         float  useZ       = extractGcodeValue(gcodeLine, 'Z', 0);

--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -1370,6 +1370,7 @@ void PIDTestPosition(Axis* axis, float start, float stop, const float steps, con
             location = start + (span * (i/(steps-1)));
         }
         startTime = micros();
+        current = micros();
         axis->write(location);
         while (startTime + (stepTime * 1000) > current){
           if (current - print > LOOPINTERVAL){
@@ -1378,9 +1379,9 @@ void PIDTestPosition(Axis* axis, float start, float stop, const float steps, con
             }
             else {
               error   =  axis->read() - location;
-              print = current;
               Serial.println(error);
             }
+            print = current;
           }
           current = micros();
         }
@@ -1395,9 +1396,9 @@ void PIDTestPosition(Axis* axis, float start, float stop, const float steps, con
         }            
         else {
           error   =  axis->read() - location;
-          print = current;
           Serial.println(error);
         }
+        print = current;
       }
       current = micros();
     }

--- a/cnc_ctrl_v1/Motor.cpp
+++ b/cnc_ctrl_v1/Motor.cpp
@@ -73,6 +73,13 @@ int Motor::lastSpeed(){
     return _lastSpeed;
 }
 
+void Motor::additiveWrite(int speed){
+    /*
+    Increases/decreases the motor speed by the passed speed amount
+    */
+    write(_lastSpeed + speed);
+}
+
 void Motor::write(int speed){
     /*
     Sets motor speed from input. Speed = 0 is stopped, -255 is full reverse, 255 is full ahead.

--- a/cnc_ctrl_v1/Motor.cpp
+++ b/cnc_ctrl_v1/Motor.cpp
@@ -66,6 +66,13 @@ void Motor::detach(){
     digitalWrite(_pwmPin,  LOW);
 }
 
+int Motor::lastSpeed(){
+    /*
+    Returns the last speed(voltage) value sent to the pwm
+    */
+    return _lastSpeed;
+}
+
 void Motor::write(int speed){
     /*
     Sets motor speed from input. Speed = 0 is stopped, -255 is full reverse, 255 is full ahead.
@@ -92,6 +99,8 @@ void Motor::write(int speed){
         
         //enforce range
         speed = constrain(speed, -255, 255);
+        
+        _lastSpeed = speed; //saves speed for use in additive write
         
         speed = abs(speed); //remove sign from input because direction is set by control pins on H-bridge
         

--- a/cnc_ctrl_v1/Motor.h
+++ b/cnc_ctrl_v1/Motor.h
@@ -38,6 +38,7 @@
             int  setupMotor(const int& pwmPin, const int& pin1, const int& pin2);
             void detach();
             void write(int speed);
+            int  lastSpeed();
             int  attached();
             int  _convolve(const int& input);
             void setSegment(const int& index, const float& slope, const float& intercept, const int& negativeBound, const int& positiveBound);
@@ -49,6 +50,7 @@
             int _pin2;
             bool _attachedState = false;
             LinSegment _linSegments[4];
+            int _lastSpeed  = 0;
             
     };
 

--- a/cnc_ctrl_v1/Motor.h
+++ b/cnc_ctrl_v1/Motor.h
@@ -39,6 +39,7 @@
             void detach();
             void write(int speed);
             int  lastSpeed();
+            void additiveWrite(int speed);
             int  attached();
             int  _convolve(const int& input);
             void setSegment(const int& index, const float& slope, const float& intercept, const int& negativeBound, const int& positiveBound);

--- a/cnc_ctrl_v1/MotorGearboxEncoder.cpp
+++ b/cnc_ctrl_v1/MotorGearboxEncoder.cpp
@@ -60,10 +60,11 @@ void  MotorGearboxEncoder::computePID(){
     /*
     Recompute the speed control PID loop and command the motor to move.
     */
-    _currentSpeed = _computeSpeed();
+    _currentSpeed = computeSpeed();
 
     _PIDController.Compute();
 
+    // motor.additiveWrite(_pidOutput);
     motor.write(_pidOutput);
 }
 
@@ -123,7 +124,7 @@ void MotorGearboxEncoder::setEncoderResolution(float resolution){
     
 }
 
-float MotorGearboxEncoder::_computeSpeed(){
+float MotorGearboxEncoder::computeSpeed(){
     /*
     
     Returns the motors speed in RPM since the last time this function was called

--- a/cnc_ctrl_v1/MotorGearboxEncoder.cpp
+++ b/cnc_ctrl_v1/MotorGearboxEncoder.cpp
@@ -91,6 +91,15 @@ String  MotorGearboxEncoder::getPIDString(){
     return PIDString + _Kp + ",Ki=" + _Ki + ",Kd=" + _Kd;
 }
 
+String  MotorGearboxEncoder::pidState(){
+    /*
+    
+    Get current value of PID variables, setpoint, input, output
+    
+    */
+    return _PIDController.pidState();
+}
+
 void MotorGearboxEncoder::setPIDAggressiveness(float aggressiveness){
     /*
     

--- a/cnc_ctrl_v1/MotorGearboxEncoder.cpp
+++ b/cnc_ctrl_v1/MotorGearboxEncoder.cpp
@@ -64,8 +64,7 @@ void  MotorGearboxEncoder::computePID(){
 
     _PIDController.Compute();
 
-    // motor.additiveWrite(_pidOutput);
-    motor.write(_pidOutput);
+    motor.additiveWrite(_pidOutput);
 }
 
 void  MotorGearboxEncoder::setPIDValues(float KpV, float KiV, float KdV){

--- a/cnc_ctrl_v1/MotorGearboxEncoder.h
+++ b/cnc_ctrl_v1/MotorGearboxEncoder.h
@@ -37,6 +37,7 @@
             void       setPIDAggressiveness(float aggressiveness);
             void       setPIDValues(float KpV, float KiV, float KdV);
             void       setEncoderResolution(float resolution);
+            float      computeSpeed();
             String     getPIDString();
             String     pidState();
         private:
@@ -51,7 +52,6 @@
             PID        _PIDController;
             double     _Kp=0, _Ki=0, _Kd=0;
             float      _encoderStepsToRPMScaleFactor = 7364.0;   //6*10^7 us per minute divided by 8148 steps per revolution
-            float      _computeSpeed();
     };
 
     #endif

--- a/cnc_ctrl_v1/MotorGearboxEncoder.h
+++ b/cnc_ctrl_v1/MotorGearboxEncoder.h
@@ -38,6 +38,7 @@
             void       setPIDValues(float KpV, float KiV, float KdV);
             void       setEncoderResolution(float resolution);
             String     getPIDString();
+            String     pidState();
         private:
             double     _targetSpeed;
             double     _currentSpeed;

--- a/cnc_ctrl_v1/PID_v1.cpp
+++ b/cnc_ctrl_v1/PID_v1.cpp
@@ -217,3 +217,20 @@ double PID::GetKd(){ return  dispKd;}
 int PID::GetMode(){ return  inAuto ? AUTOMATIC : MANUAL;}
 int PID::GetDirection(){ return controllerDirection;}
 double PID::GetIterm(){ return outputSum; }
+String PID::pidState() {
+    /*
+    Returns a comma seperated string of the PID setpoint, input, & output
+    useful for debugging
+    */
+    double input = *myInput;
+    double setpoint = *mySetpoint;
+    double output = *myOutput;
+    String ret = "";
+    ret.concat((double)setpoint);
+    ret.concat(",");
+    ret.concat((double)input);
+    ret.concat(",");
+    ret.concat((double)output);
+    return ret;
+}
+

--- a/cnc_ctrl_v1/PID_v1.h
+++ b/cnc_ctrl_v1/PID_v1.h
@@ -64,6 +64,7 @@ class PID
 	int GetMode();						  //  inside the PID.
 	int GetDirection();					  //
     double GetIterm();
+  String pidState();
 
   private:
 	void Initialize();


### PR DESCRIPTION
In short, this makes it so that the velocity controller tracks the current voltage applied to the motor and then adds or subtracts voltage to achieve the desired speed.  This results in much less spiky voltage output and hopefully a smoother operation.

This also improves upon the PID positional testing report by adding a version 2 (v2) option which outputs much more information at once.

I also added a B16 command which runs the motors at selected voltages and then outputs the rpm for those voltages.  This is helpful for characterizing the motors.

This merge requires using new PID values, so it should be merged with the corresponding changes to Ground Control https://github.com/MaslowCNC/GroundControl/pull/485