### PR TITLE
Include Sprocket Geometry in Triangular Kinematics

### DIFF
--- a/cnc_ctrl_v1/Kinematics.cpp
+++ b/cnc_ctrl_v1/Kinematics.cpp
@@ -193,8 +193,13 @@ void  Kinematics::triangularInverse(float xTarget,float yTarget, float* aChainLe
     //Confirm that the coordinates are on the wood
     _verifyValidTarget(&xTarget, &yTarget);
     
-    float Chain1 = sqrt(pow((-1*_xCordOfMotor - xTarget),2)+pow((_yCordOfMotor - yTarget),2));
-    float Chain2 = sqrt(pow((_xCordOfMotor - xTarget),2)+pow((_yCordOfMotor - yTarget),2));
+    //Calculate motor axes length to the bit
+    float Motor1Distance = sqrt(pow((-1*_xCordOfMotor - xTarget),2)+pow((_yCordOfMotor - yTarget),2));
+    float Motor2Distance = sqrt(pow((_xCordOfMotor - xTarget),2)+pow((_yCordOfMotor - yTarget),2));
+    
+    //Calculate chain lengths accounting for sprocket geometry
+    float Chain1 = (R * (3.14159 - acos(R/Motor1Distance) - acos((_yCordOfMotor - yTarget)/Motor1Distance))) + sqrt(pow(Motor1Distance,2)-pow(R,2));
+    float Chain2 = (R * (3.14159 - acos(R/Motor2Distance) - acos((_yCordOfMotor - yTarget)/Motor2Distance))) + sqrt(pow(Motor2Distance,2)-pow(R,2));
     
     //Subtract of the virtual length which is added to the chain by the rotation mechanism
     Chain1 = Chain1 - rotationDiskRadius;

--- a/cnc_ctrl_v1/Kinematics.h
+++ b/cnc_ctrl_v1/Kinematics.h
@@ -105,6 +105,10 @@
             float Lambda;
             float Gamma;
 
+            // Motor axes length to the bit for triangular kinematics
+            float Motor1Distance; //left motor axis distance to sled
+            float Motor2Distance; //right motor axis distance to sled
+
             // output = chain lengths measured from 12 o'clock
             float Chain1; //left chain length 
             float Chain2; //right chain length


### PR DESCRIPTION
Updated the chain length calculations for triangular kinematics to include sprocket geometry effects.

Accounted for chain length wrapped around the sprocket as well as difference in distance of the chain on the sprocket compared to the motor axes.

Additional discussion, as well as an explanation of the geometry involved can be found at: https://forums.maslowcnc.com/t/accounting-for-motor-sprocket-induced-error-when-calculating-chain-lengths/1422