### PR TITLE
Fix for z not retracting before moving home

### DIFF
--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -46,8 +46,8 @@ bool zAxisAuto = false;
 #define MILLIMETERS 1
 #define INCHES      25.4
 #define MAXFEED     1000      //The maximum allowable feedrate in mm/min
-#define MAXZROTMIN  12.60    // the maximum z rotations per minute
-#define LOOPINTERVAL 10000     // What is the frequency of the PID loop in microseconds
+#define MAXZROTMIN  12.60     // the maximum z rotations per minute
+#define LOOPINTERVAL 10000    // What is the frequency of the PID loop in microseconds
 
 int ENCODER1A;
 int ENCODER1B;
@@ -373,6 +373,14 @@ bool checkForStopCommand(){
 }
 
 void  holdPosition(){
+    /*
+    
+    This function is called every time the main loop runs. When the machine is executing a move it is not called, but when the machine is
+    not executing a line it is called regularly and causes the motors to hold their positions.
+    
+    */
+    checkForStopCommand();
+    
     leftAxis.hold();
     rightAxis.hold();
     zAxis.hold();


### PR DESCRIPTION
What's happening is that since checkForStopCommand() is not called unless the machine is moving. A stop stop sent when the machine is not running causes issues.

The stop command (!) will sit in the buffer until a move command is sent. As soon as the move command is processed, the stop is detected and the move command is not executed.

The solution is to also check for the stop command when the machine is not moving.