### PR TITLE
Update CNC_Functions.h

### DIFF
--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -1738,7 +1738,7 @@ void  executeMcodeLine(const String& gcodeLine){
             setSpindlePower(true);  // turn on spindle
             break;
         case 6:   // Tool Change
-            if (nextTool > 0) {
+            if (nextTool != lastTool) {
                 setSpindlePower(false); // first, turn off spindle
                 Serial.print(F("Tool Change: Please insert tool "));   // prompt user to change tool
                 Serial.println(nextTool);


### PR DESCRIPTION
Current code only pauses when the next tool ID is >0.   By comparing nextTool to lastTool, all changes in tools will result in a pause, including when changing back to T0.

This happened to me this weekend when the gcode makercam produced put my 1/8-bit as T1 and my 1/4-inch bit as T0.  I did my pocket and follow work with T1 and then cut out the piece with T0.  The firmware did not pause when it got the command to switch back to T0.