### PR TITLE
Change Encoder Steps to Float

### DIFF
--- a/cnc_ctrl_v1/Axis.cpp
+++ b/cnc_ctrl_v1/Axis.cpp
@@ -184,7 +184,7 @@ float  Axis::getPitch(){
     return _mmPerRotation;
 }
 
-void   Axis::changeEncoderResolution(const int& newResolution){
+void   Axis::changeEncoderResolution(const float& newResolution){
     /*
     Reassign the encoder resolution for the axis.
     */

--- a/cnc_ctrl_v1/Axis.h
+++ b/cnc_ctrl_v1/Axis.h
@@ -46,7 +46,7 @@
             void   test();
             void   changePitch(const float& newPitch);
             float  getPitch();
-            void   changeEncoderResolution(const int& newResolution);
+            void   changeEncoderResolution(const float& newResolution);
             bool   attached();
             void   wipeEEPROM();
             MotorGearboxEncoder    motorGearboxEncoder;

--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -1135,12 +1135,12 @@ void updateMotorSettings(const String& readString){
     if (extractGcodeValue(readString, 'I', -1) != -1){
         zAxisAttached            = extractGcodeValue(readString, 'I', -1);
     }
-    int encoderSteps         = extractGcodeValue(readString, 'J', -1);
+    float encoderSteps         = extractGcodeValue(readString, 'J', -1);
     float gearTeeth          = extractGcodeValue(readString, 'K', -1);
     float chainPitch         = extractGcodeValue(readString, 'M', -1);
     
     float zDistPerRot        = extractGcodeValue(readString, 'N', -1);
-    int zEncoderSteps        = extractGcodeValue(readString, 'P', -1);
+    float zEncoderSteps        = extractGcodeValue(readString, 'P', -1);
     
     float propWeight         = extractGcodeValue(readString, 'R', -1);
     float KpPos              = extractGcodeValue(readString, 'S', -1);


### PR DESCRIPTION
The encoderSteps and zEncoderSteps variables were changed from int to float, and the changeEncoderResolution function updated accordingly.

Full discussion at: https://forums.maslowcnc.com/t/what-is-correct-chain-pitch/1430/