### PR TITLE
Add a Simple Fake Servo Option

### DIFF
--- a/cnc_ctrl_v1/Axis.cpp
+++ b/cnc_ctrl_v1/Axis.cpp
@@ -84,6 +84,15 @@ void   Axis::setSteps(const long& steps){
 
 void   Axis::computePID(){
     
+    #ifdef FAKE_SERVO
+      static unsigned long lastPrint = millis();
+      if (motorGearboxEncoder.motor.attached()){
+        // Adds up to 10% error just to simulate servo noise
+        double rpm = (-1 * _pidOutput) * random(90, 110) / 100;
+        unsigned long steps = motorGearboxEncoder.encoder.read() + round( rpm * *_encoderSteps * LOOPINTERVAL)/(60 * 1000000);
+        motorGearboxEncoder.encoder.write(steps);
+      }
+    #endif
 
     if (_disableAxisForTesting || !motorGearboxEncoder.motor.attached()){
         return;

--- a/cnc_ctrl_v1/Config.h
+++ b/cnc_ctrl_v1/Config.h
@@ -25,6 +25,10 @@
                            // LOOPINTERVAL tuning
 #define KINEMATICSDBG 0    // set to 1 for additional kinematics debug messaging
 
+// #define FAKE_SERVO      // Uncomment this line to cause the Firmware to mimic
+                           // a servo updating the encoder steps even if no servo
+                           // is connected.  Useful for testing on an arduino only
+
 
 #define LOOPINTERVAL 10000 // What is the frequency of the PID loop in microseconds
 


### PR DESCRIPTION
This is very basic.

If FAKE_SERVO is defined, each PID cycle it will look at what the last requested PID rpm was and will update the encoder steps as though a motor operated at that speed for the amount of loopinterval. 

It adds up to 10% error to mimic servo noise.  It doesn't do a great job of testing the PID settings (this would be tough) and doesn't verify that the encoder library is working.  But other than that I think this tests the rest of the code in the Firmware.

It closes #361 