### PR TITLE
Catch extra 'ok' message sent on  manual z-axis move

### DIFF
--- a/cnc_ctrl_v1/GCode.cpp
+++ b/cnc_ctrl_v1/GCode.cpp
@@ -48,7 +48,6 @@ void readSerialCommands(){
             }
             else if (c == '~'){
                 bit_false(sys.pause, PAUSE_FLAG_USER_PAUSE);
-                reportStatusMessage(STATUS_OK);
             }
             else{
                 int bufferOverflow = incSerialBuffer.write(c); //gets one byte from serial buffer, writes it to the internal ring buffer
@@ -580,7 +579,7 @@ void gcodeExecuteLoop(){
       status = interpretCommandString(readyCommandString);
       readyCommandString = "";
 
-      // Get next line of GCode
+      // Get next line of GCode (This will send an 'ok' command)
       if (!sys.stop){reportStatusMessage(status);}
   }
 }
@@ -634,12 +633,9 @@ int   G1(const String& readString, int G0orG1){
             else{
                 Serial.println(F(" mm"));
             }
-            
             pause(); //Wait until the z-axis is adjusted
             
             zAxis.set(zgoto);
-
-            maslowDelay(1000);
         }
     }
     


### PR DESCRIPTION
The firmware was sending an extra 'ok' status when paused prompting the machine to gain one extra line in the buffer with each z-axis adjustment eventually overflowing the buffer.

The solution is to remove the extra command which does not seem to be needed for operation with our without the z-axis.

The pause command does not seem to be effected.

Fixes #366