### PR TITLE
Catch Line Ending on Quick Commands; Remove Watchdog

### DIFF
--- a/cnc_ctrl_v1/GCode.cpp
+++ b/cnc_ctrl_v1/GCode.cpp
@@ -38,19 +38,29 @@ void readSerialCommands(){
     if this is a necessary character write to the incSerialBuffer otherwise discard
     it.
     */
+    
+    static bool quickCommandFlag = false;
+    
     if (Serial.available() > 0) {
         while (Serial.available() > 0) {
             char c = Serial.read();
             if (c == '!'){
                 sys.stop = true;
+                quickCommandFlag = true;
                 bit_false(sys.pause, PAUSE_FLAG_USER_PAUSE);
                 reportStatusMessage(STATUS_OK);
             }
             else if (c == '~'){
+                quickCommandFlag = true;
                 bit_false(sys.pause, PAUSE_FLAG_USER_PAUSE);
                 reportStatusMessage(STATUS_OK);
             }
+            // else if (quickCommandFlag and c == '\n'){
+            //   // Catch line ending and ignore after quick commands
+            //   quickCommandFlag = false;
+            // }
             else{
+                quickCommandFlag = false;
                 int bufferOverflow = incSerialBuffer.write(c); //gets one byte from serial buffer, writes it to the internal ring buffer
                 if (bufferOverflow != 0) {
                   sys.stop = true;

--- a/cnc_ctrl_v1/GCode.cpp
+++ b/cnc_ctrl_v1/GCode.cpp
@@ -55,10 +55,10 @@ void readSerialCommands(){
                 bit_false(sys.pause, PAUSE_FLAG_USER_PAUSE);
                 reportStatusMessage(STATUS_OK);
             }
-            // else if (quickCommandFlag and c == '\n'){
-            //   // Catch line ending and ignore after quick commands
-            //   quickCommandFlag = false;
-            // }
+            else if (quickCommandFlag and c == '\n'){
+              // Catch line ending and ignore after quick commands
+              quickCommandFlag = false;
+            }
             else{
                 quickCommandFlag = false;
                 int bufferOverflow = incSerialBuffer.write(c); //gets one byte from serial buffer, writes it to the internal ring buffer

--- a/cnc_ctrl_v1/System.cpp
+++ b/cnc_ctrl_v1/System.cpp
@@ -235,6 +235,7 @@ void systemSaveAxesPosition(){
 
 // This should be the ultimate fallback, it would be best if we didn't even need 
 // something like this at all
+// TODO delete this function, we are not even using it anymore
 void  _watchDog(){
     /*
     If:

--- a/cnc_ctrl_v1/cnc_ctrl_v1.ino
+++ b/cnc_ctrl_v1/cnc_ctrl_v1.ino
@@ -87,7 +87,5 @@ void loop(){
         gcodeExecuteLoop();
         
         execSystemRealtime();
-    
-        _watchDog();
     }
 }


### PR DESCRIPTION
Need to discard any line endings sent after a quick command
otherwise they get interpreted as a blank line and an OK is
sent.  I am not super thrilled with how I wrote this, but I
think it is reasonably compact and logical.

REMOVE WATCHDOG.  This was also causing an issue when the
machine paused itself waiting for a manual Z change.  If
the buffer was empty, it would send an OK requesting a new
line.  We just need to be careful now to make sure that all
OKs are properly sent.

This along with changes to GC closes #366 