### PR TITLE
Chain Sag Correction for Triangular Kinematics

### DIFF
--- a/cnc_ctrl_v1/Kinematics.cpp
+++ b/cnc_ctrl_v1/Kinematics.cpp
@@ -203,11 +203,23 @@ void  Kinematics::triangularInverse(float xTarget,float yTarget, float* aChainLe
     //Calculate motor axes length to the bit
     float Motor1Distance = sqrt(pow((-1*_xCordOfMotor - xTarget),2)+pow((_yCordOfMotor - yTarget),2));
     float Motor2Distance = sqrt(pow((_xCordOfMotor - xTarget),2)+pow((_yCordOfMotor - yTarget),2));
-    
-    //Calculate chain lengths accounting for sprocket geometry
-    float Chain1 = (R * (3.14159 - acos(R/Motor1Distance) - acos((_yCordOfMotor - yTarget)/Motor1Distance))) + sqrt(pow(Motor1Distance,2)-pow(R,2));
-    float Chain2 = (R * (3.14159 - acos(R/Motor2Distance) - acos((_yCordOfMotor - yTarget)/Motor2Distance))) + sqrt(pow(Motor2Distance,2)-pow(R,2));
-    
+
+    //Calculate the chain angles from horizontal
+    float Chain1Angle = 3.14159 - acos(R/Motor1Distance) - acos((_yCordOfMotor - yTarget)/Motor1Distance)
+    float Chain2Angle = 3.14159 - acos(R/Motor2Distance) - acos((_yCordOfMotor - yTarget)/Motor2Distance)
+
+    //Calculate the straight chain length from the sprocket to the bit
+    float Chain1Straight = sqrt(pow(Motor1Distance,2)-pow(R,2))
+    float Chain2Straight = sqrt(pow(Motor2Distance,2)-pow(R,2))
+
+    //Correct the straight chain lengths to account for chain sag
+    Chain1Straight *= (1 + ((sysSettings.chainSagCorrection / 1000000000000) * pow(cos(Chain1Angle),2) * pow(Chain1Straight,2) * pow((tan(Chain2Angle) * cos(Chain1Angle)) + sin(Chain1Angle),2)))
+    Chain2Straight *= (1 + ((sysSettings.chainSagCorrection / 1000000000000) * pow(cos(Chain2Angle),2) * pow(Chain2Straight,2) * pow((tan(Chain1Angle) * cos(Chain2Angle)) + sin(Chain2Angle),2)))
+
+    //Calculate total chain lengths accounting for sprocket geometry and chain sag
+    float Chain1 = (R * Chain1Angle) + Chain1Straight;
+    float Chain2 = (R * Chain2Angle) + Chain2Straight;
+
     //Subtract of the virtual length which is added to the chain by the rotation mechanism
     Chain1 = Chain1 - sysSettings.rotationDiskRadius;
     Chain2 = Chain2 - sysSettings.rotationDiskRadius;

--- a/cnc_ctrl_v1/Kinematics.cpp
+++ b/cnc_ctrl_v1/Kinematics.cpp
@@ -205,16 +205,16 @@ void  Kinematics::triangularInverse(float xTarget,float yTarget, float* aChainLe
     float Motor2Distance = sqrt(pow((_xCordOfMotor - xTarget),2)+pow((_yCordOfMotor - yTarget),2));
 
     //Calculate the chain angles from horizontal
-    float Chain1Angle = 3.14159 - acos(R/Motor1Distance) - acos((_yCordOfMotor - yTarget)/Motor1Distance)
-    float Chain2Angle = 3.14159 - acos(R/Motor2Distance) - acos((_yCordOfMotor - yTarget)/Motor2Distance)
+    float Chain1Angle = 3.14159 - acos(R/Motor1Distance) - acos((_yCordOfMotor - yTarget)/Motor1Distance);
+    float Chain2Angle = 3.14159 - acos(R/Motor2Distance) - acos((_yCordOfMotor - yTarget)/Motor2Distance);
 
     //Calculate the straight chain length from the sprocket to the bit
-    float Chain1Straight = sqrt(pow(Motor1Distance,2)-pow(R,2))
-    float Chain2Straight = sqrt(pow(Motor2Distance,2)-pow(R,2))
+    float Chain1Straight = sqrt(pow(Motor1Distance,2)-pow(R,2));
+    float Chain2Straight = sqrt(pow(Motor2Distance,2)-pow(R,2));
 
     //Correct the straight chain lengths to account for chain sag
-    Chain1Straight *= (1 + ((sysSettings.chainSagCorrection / 1000000000000) * pow(cos(Chain1Angle),2) * pow(Chain1Straight,2) * pow((tan(Chain2Angle) * cos(Chain1Angle)) + sin(Chain1Angle),2)))
-    Chain2Straight *= (1 + ((sysSettings.chainSagCorrection / 1000000000000) * pow(cos(Chain2Angle),2) * pow(Chain2Straight,2) * pow((tan(Chain1Angle) * cos(Chain2Angle)) + sin(Chain2Angle),2)))
+    Chain1Straight *= (1 + ((sysSettings.chainSagCorrection / 1000000000000) * pow(cos(Chain1Angle),2) * pow(Chain1Straight,2) * pow((tan(Chain2Angle) * cos(Chain1Angle)) + sin(Chain1Angle),2)));
+    Chain2Straight *= (1 + ((sysSettings.chainSagCorrection / 1000000000000) * pow(cos(Chain2Angle),2) * pow(Chain2Straight,2) * pow((tan(Chain1Angle) * cos(Chain2Angle)) + sin(Chain2Angle),2)));
 
     //Calculate total chain lengths accounting for sprocket geometry and chain sag
     float Chain1 = (R * Chain1Angle) + Chain1Straight;

--- a/cnc_ctrl_v1/Report.cpp
+++ b/cnc_ctrl_v1/Report.cpp
@@ -200,8 +200,8 @@ void reportMaslowSettings() {
     Serial.print(F(" (z axis Kp Velocity)\r\n$34=")); Serial.print(sysSettings.zKiV);
     Serial.print(F(" (z axis Ki Velocity)\r\n$35=")); Serial.print(sysSettings.zKdV);
     Serial.print(F(" (z axis Kd Velocity)\r\n$36=")); Serial.print(sysSettings.zPropWeightV);
-    Serial.print(F(" (chain sag correction value, $K)\r\n$37=")); Serial.print(sysSettings.chainSagCorrection);
-    Serial.println(F(" (z axis Velocity proportional weight)"));
+    Serial.print(F(" (z axis Velocity proportional weight)\r\n$37=")); Serial.print(sysSettings.chainSagCorrection);
+    Serial.println(F(" (chain sag correction value)"));
   #endif
 }
 

--- a/cnc_ctrl_v1/Report.cpp
+++ b/cnc_ctrl_v1/Report.cpp
@@ -163,6 +163,7 @@ void reportMaslowSettings() {
     Serial.print(F("$34=")); Serial.println(sysSettings.zKiV);
     Serial.print(F("$35=")); Serial.println(sysSettings.zKdV);
     Serial.print(F("$36=")); Serial.println(sysSettings.zPropWeightV);
+    Serial.print(F("$37=")); Serial.println(sysSettings.chainSagCorrection);
   #else
     Serial.print(F("$0=")); Serial.print(sysSettings.machineWidth);
     Serial.print(F(" (machine width, mm, $K)\r\n$1=")); Serial.print(sysSettings.machineHeight);
@@ -199,6 +200,7 @@ void reportMaslowSettings() {
     Serial.print(F(" (z axis Kp Velocity)\r\n$34=")); Serial.print(sysSettings.zKiV);
     Serial.print(F(" (z axis Ki Velocity)\r\n$35=")); Serial.print(sysSettings.zKdV);
     Serial.print(F(" (z axis Kd Velocity)\r\n$36=")); Serial.print(sysSettings.zPropWeightV);
+    Serial.print(F(" (chain sag correction value, $K)\r\n$37=")); Serial.print(sysSettings.chainSagCorrection);
     Serial.println(F(" (z axis Velocity proportional weight)"));
   #endif
 }

--- a/cnc_ctrl_v1/Settings.cpp
+++ b/cnc_ctrl_v1/Settings.cpp
@@ -102,6 +102,7 @@ void settingsReset() {
     sysSettings.zKiV = 0.0;    // float zKiV;
     sysSettings.zKdV = 0.28;   // float zKdV;
     sysSettings.zPropWeightV = 1.0;    // float zPropWeightV;
+    sysSettings.chainSagCorrection = 0.0;  // float chainSagCorrection;
     sysSettings.eepromValidData = EEPROMVALIDDATA; // byte eepromValidData;
 }
 
@@ -380,6 +381,9 @@ byte settingsStoreGlobalSetting(const byte& parameter,const float& value){
             }
             zAxis.setPIDValues(&sysSettings.zKpPos, &sysSettings.zKiPos, &sysSettings.zKdPos, &sysSettings.zPropWeightPos, &sysSettings.zKpV, &sysSettings.zKiV, &sysSettings.zKdV, &sysSettings.zPropWeightV);
             break;
+        case 37:
+              sysSettings.chainSagCorrection = value;
+              break;
         default:
               return(STATUS_INVALID_STATEMENT);
     }

--- a/cnc_ctrl_v1/Settings.h
+++ b/cnc_ctrl_v1/Settings.h
@@ -20,8 +20,8 @@ Copyright 2014-2017 Bar Smith*/
 #ifndef settings_h
 #define settings_h
 
-#define SETTINGSVERSION 1      // The current version of settings, if this doesn't
-                               // match what is in EEPROM then settings on 
+#define SETTINGSVERSION 2      // The current version of settings, if this doesn't
+                               // match what is in EEPROM then settings on
                                // machine are reset to defaults
 #define EEPROMVALIDDATA 56     // This is just a random byte value that is used 
                                // to determine if the data in the EEPROM was 
@@ -42,6 +42,7 @@ typedef struct {  // I think this is about ~128 bytes in size if I counted corre
   float sledCG;
   byte kinematicsType;
   float rotationDiskRadius;
+  float chainSagCorrection;
   unsigned int axisDetachTime;
   unsigned int originalChainLength;
   float encoderSteps;

--- a/cnc_ctrl_v1/Settings.h
+++ b/cnc_ctrl_v1/Settings.h
@@ -42,7 +42,6 @@ typedef struct {  // I think this is about ~128 bytes in size if I counted corre
   float sledCG;
   byte kinematicsType;
   float rotationDiskRadius;
-  float chainSagCorrection;
   unsigned int axisDetachTime;
   unsigned int originalChainLength;
   float encoderSteps;
@@ -69,6 +68,7 @@ typedef struct {  // I think this is about ~128 bytes in size if I counted corre
   float zKiV;
   float zKdV;
   float zPropWeightV;
+  float chainSagCorrection;
   byte eepromValidData;  // This should always be last, that way if an error
                          // happens in writing, it will not be written and we
 } settings_t;            // will know to reset the settings


### PR DESCRIPTION
This updates the triangular kinematics formulas to correct for chain sag. It utilizes a new parameter, chainSagCorrection, which is determined by a new GroundControl calibration process.

I associated parameter number 37 with the new chainSagCorrection parameter, as I believe that was the next unused parameter.

An associated GroundControl PR will be submitted shortly.