### PR TITLE
Rework motor commands to avoid PWM on pin12

### DIFF
--- a/cnc_ctrl_v1/Motor.cpp
+++ b/cnc_ctrl_v1/Motor.cpp
@@ -90,16 +90,16 @@ void Motor::write(int speed){
 
       if(_pwmPin == 12){
           if (forward){
-              analogWrite(_pin1 , abs(speed));
-              digitalWrite(_pin2, LOW);
-              digitalWrite(_pwmPin, HIGH);
+              analogWrite(_pin1 , speed);  // PWM on this pin to avoid using pin12 (timer1)
+              digitalWrite(_pin2, LOW);    // this pin sets direction with respect to _pin1 
+              digitalWrite(_pwmPin, HIGH); // this pin enables the outputs of the other two
           }
           else if (speed == 0){
           }
           else{
-              analogWrite(_pin1 , 255 - abs(speed));
-              digitalWrite(_pin2, HIGH);
-              digitalWrite(_pwmPin, HIGH);
+              analogWrite(_pin1 , 255 - speed); // PWM signal is inverted to cause reverse motion
+              digitalWrite(_pin2, HIGH);        // setting this pin HIGH causes _pin1 PWM to drive reverse
+              digitalWrite(_pwmPin, HIGH);      // enable the output
           }        
       } else {
           if (forward){
@@ -124,17 +124,17 @@ void Motor::directWrite(int voltage){
     
     if(_pwmPin == 12){
         if (voltage > 0){
-            analogWrite(_pin1 , abs(voltage));
-            digitalWrite(_pin2, LOW);
-            digitalWrite(_pwmPin, HIGH);
+            analogWrite(_pin1 , abs(voltage)); // PWM on this pin to avoid using pin12 (timer1)
+            digitalWrite(_pin2, LOW);          // this pin sets direction with respect to _pin1 
+            digitalWrite(_pwmPin, HIGH);       // this pin enables the outputs of the other two
         }
         else if (voltage == 0){
             voltage = voltage;
         }
         else{
-            analogWrite(_pin1 , 255 - abs(voltage));
-            digitalWrite(_pin2, HIGH);
-            digitalWrite(_pwmPin, HIGH);
+            analogWrite(_pin1 , 255 - abs(voltage)); // PWM signal is inverted to cause reverse motion
+            digitalWrite(_pin2, HIGH);               // setting this pin HIGH causes _pin1 PWM to drive reverse
+            digitalWrite(_pwmPin, HIGH);             // enable the output
         }
     }
     else{

--- a/cnc_ctrl_v1/Motor.cpp
+++ b/cnc_ctrl_v1/Motor.cpp
@@ -83,42 +83,37 @@ void Motor::write(int speed){
     Sets motor speed from input. Speed = 0 is stopped, -255 is full reverse, 255 is full ahead.
     */
     if (_attachedState == 1){
-        
-        //linearize the motor
-        //speed = _convolve(speed);
-        
-        //set direction range is 0-180
-        if (speed > 0){
-            digitalWrite(_pin1 , HIGH);
-            digitalWrite(_pin2 , LOW );
-            speed = speed;
-        }
-        else if (speed == 0){
-            speed = speed;
-        }
-        else{
-            digitalWrite(_pin1 , LOW);
-            digitalWrite(_pin2 , HIGH );
-            speed = speed;
-        }
-        
-        //enforce range
-        speed = constrain(speed, -255, 255);
-        
-        _lastSpeed = speed; //saves speed for use in additive write
-        
-        speed = abs(speed); //remove sign from input because direction is set by control pins on H-bridge
-        
-        int pwmFrequency = round(speed);
-        
-        if(_pwmPin == 12){
-            pwmFrequency = map(pwmFrequency, 0, 255, 0, 1023);  //Scales 0-255 to 0-1023
-            Timer1.pwm(2, pwmFrequency);  //Special case for pin 12 due to timer blocking analogWrite()
-        }
-        else{
-            analogWrite(_pwmPin, pwmFrequency);
-        }
-        
+      speed = constrain(speed, -255, 255);
+      _lastSpeed = speed; //saves speed for use in additive write
+      bool forward = (speed > 0);
+      speed = abs(speed); //remove sign from input because direction is set by control pins on H-bridge   
+
+      if(_pwmPin == 12){
+          if (forward){
+              analogWrite(_pin1 , abs(speed));
+              digitalWrite(_pin2, LOW);
+              digitalWrite(_pwmPin, HIGH);
+          }
+          else if (speed == 0){
+          }
+          else{
+              analogWrite(_pin1 , 255 - abs(speed));
+              digitalWrite(_pin2, HIGH);
+              digitalWrite(_pwmPin, HIGH);
+          }        
+      } else {
+          if (forward){
+              digitalWrite(_pin1 , HIGH);
+              digitalWrite(_pin2 , LOW );
+          }
+          else if (speed == 0){
+          }
+          else{
+              digitalWrite(_pin1 , LOW);
+              digitalWrite(_pin2 , HIGH );
+          }
+          analogWrite(_pwmPin, speed);
+      }
     }
 }
 
@@ -127,24 +122,33 @@ void Motor::directWrite(int voltage){
     Write directly to the motor, ignoring if the axis is attached or any applied calibration.
     */
     
-    if (voltage > 0){
-        digitalWrite(_pin1 , HIGH);
-        digitalWrite(_pin2 , LOW );
-    }
-    else if (voltage == 0){
-        voltage = voltage;
-    }
-    else{
-        digitalWrite(_pin1 , LOW);
-        digitalWrite(_pin2 , HIGH );
-    }
-    
     if(_pwmPin == 12){
-        voltage = abs(voltage);
-        voltage = map(voltage, 0, 255, 0, 1023);  //Scales 0-255 to 0-1023
-        Timer1.pwm(2, voltage);  //Special case for pin 12 due to timer blocking analogWrite()
+        if (voltage > 0){
+            analogWrite(_pin1 , abs(voltage));
+            digitalWrite(_pin2, LOW);
+            digitalWrite(_pwmPin, HIGH);
+        }
+        else if (voltage == 0){
+            voltage = voltage;
+        }
+        else{
+            analogWrite(_pin1 , 255 - abs(voltage));
+            digitalWrite(_pin2, HIGH);
+            digitalWrite(_pwmPin, HIGH);
+        }
     }
     else{
+        if (voltage > 0){
+            digitalWrite(_pin1 , HIGH);
+            digitalWrite(_pin2 , LOW );
+        }
+        else if (voltage == 0){
+            voltage = voltage;
+        }
+        else{
+            digitalWrite(_pin1 , LOW);
+            digitalWrite(_pin2 , HIGH );
+        }
         analogWrite(_pwmPin, abs(voltage));
     }
 }


### PR DESCRIPTION
On the Rev.1.1 boards the PWM for the left motor is controlled by pin12. This pin is controlled by timer1 which is also used by the TimerOne library for much of the important timing for the firmware. This PR avoids PWM on pin12 altogether by applying the PWM to a different motor control.

This should make it easier to tune the PID settings, and allow changing the PWM frequencies for the three motors (right motor is on timer3, z motor timer4, left motor now on timer2) without affecting other parts of the software. This PR does not alter the frequencies however.

I've bench tested it to see that the motors move in the expected manner, but haven't run any of the frame calibrations with it yet. I think I've preserved the proper workings of the speed and _lastspeed variables.