### PR TITLE
Fix for issue #379 (won't start again after stop)

### DIFF
--- a/cnc_ctrl_v1/GCode.cpp
+++ b/cnc_ctrl_v1/GCode.cpp
@@ -591,7 +591,7 @@ void gcodeExecuteLoop(){
       readyCommandString = "";
 
       // Get next line of GCode
-      if (!sys.stop){reportStatusMessage(status);}
+      reportStatusMessage(status);
   }
 }
 

--- a/cnc_ctrl_v1/System.cpp
+++ b/cnc_ctrl_v1/System.cpp
@@ -233,36 +233,6 @@ void systemSaveAxesPosition(){
     }
 }
 
-// This should be the ultimate fallback, it would be best if we didn't even need 
-// something like this at all
-// TODO delete this function, we are not even using it anymore
-void  _watchDog(){
-    /*
-    If:
-      No incoming serial in 5 seconds 
-      Motors are detached
-      Nothing in Serial buffer
-      Watchdog has not run in 5 seconds
-    Then:
-      Send an ok message
-    
-    This fixes the issue where the machine is ready, but Ground Control doesn't know the machine is ready and the system locks up.
-    */
-    static unsigned long lastRan = millis();
-    
-    if ( millis() - sys.lastSerialRcvd > 5000 &&
-        (millis() - lastRan) > 5000 && 
-        !leftAxis.attached() and !rightAxis.attached() and !zAxis.attached() &&
-        incSerialBuffer.length() == 0
-       ){
-          #if defined (verboseDebug) && verboseDebug > 0              
-            Serial.println(F("_watchDog requesting new code"));
-          #endif
-          reportStatusMessage(STATUS_OK);
-          lastRan = millis();
-    }
-}
-
 void systemReset(){
     /* 
     Stops everything and resets the arduino


### PR DESCRIPTION
Fixes issue #379, the machine won't start again after stop. Basically, the line is being cleared from the buffer when the stop command is recieved, but no OK is being sent to indicate the space is free. It seems counter intuitive to send an OK message when the machine is stopped, but the buffer space is available.

Is this the right fix?