### PR TITLE
Add Chain Wrap Direction

### DIFF
--- a/cnc_ctrl_v1/Kinematics.cpp
+++ b/cnc_ctrl_v1/Kinematics.cpp
@@ -204,9 +204,21 @@ void  Kinematics::triangularInverse(float xTarget,float yTarget, float* aChainLe
     float Motor1Distance = sqrt(pow((-1*_xCordOfMotor - xTarget),2)+pow((_yCordOfMotor - yTarget),2));
     float Motor2Distance = sqrt(pow((_xCordOfMotor - xTarget),2)+pow((_yCordOfMotor - yTarget),2));
 
-    //Calculate the chain angles from horizontal
-    float Chain1Angle = 3.14159 - acos(R/Motor1Distance) - acos((_yCordOfMotor - yTarget)/Motor1Distance);
-    float Chain2Angle = 3.14159 - acos(R/Motor2Distance) - acos((_yCordOfMotor - yTarget)/Motor2Distance);
+    //Calculate the chain angles from horizontal, based on if the chain connects to the sled from the top or bottom of the sprocket
+    if(sysSettings.chainOverSprocket == 1){
+        float Chain1Angle = asin((_yCordOfMotor - yTarget)/Motor1Distance) + asin(R/Motor1Distance);
+        float Chain2Angle = asin((_yCordOfMotor - yTarget)/Motor2Distance) + asin(R/Motor2Distance);
+
+        float Chain1AroundSprocket = R * Chain1Angle;
+        float Chain2AroundSprocket = R * Chain2Angle;
+    }
+    else{
+        float Chain1Angle = asin((_yCordOfMotor - yTarget)/Motor1Distance) - asin(R/Motor1Distance);
+        float Chain2Angle = asin((_yCordOfMotor - yTarget)/Motor2Distance) - asin(R/Motor2Distance);
+
+        float Chain1AroundSprocket = R * (3.14159 - Chain1Angle);
+        float Chain2AroundSprocket = R * (3.14159 - Chain2Angle);
+    }
 
     //Calculate the straight chain length from the sprocket to the bit
     float Chain1Straight = sqrt(pow(Motor1Distance,2)-pow(R,2));
@@ -217,8 +229,8 @@ void  Kinematics::triangularInverse(float xTarget,float yTarget, float* aChainLe
     Chain2Straight *= (1 + ((sysSettings.chainSagCorrection / 1000000000000) * pow(cos(Chain2Angle),2) * pow(Chain2Straight,2) * pow((tan(Chain1Angle) * cos(Chain2Angle)) + sin(Chain2Angle),2)));
 
     //Calculate total chain lengths accounting for sprocket geometry and chain sag
-    float Chain1 = (R * Chain1Angle) + Chain1Straight;
-    float Chain2 = (R * Chain2Angle) + Chain2Straight;
+    float Chain1 = Chain1AroundSprocket + Chain1Straight;
+    float Chain2 = Chain2AroundSprocket + Chain2Straight;
 
     //Subtract of the virtual length which is added to the chain by the rotation mechanism
     Chain1 = Chain1 - sysSettings.rotationDiskRadius;

--- a/cnc_ctrl_v1/Kinematics.cpp
+++ b/cnc_ctrl_v1/Kinematics.cpp
@@ -199,25 +199,31 @@ void  Kinematics::triangularInverse(float xTarget,float yTarget, float* aChainLe
     
     //Confirm that the coordinates are on the wood
     _verifyValidTarget(&xTarget, &yTarget);
-    
+
+    //Set up variables
+    float Chain1Angle = 0;
+    float Chain2Angle = 0;
+    float Chain1AroundSprocket = 0;
+    float Chain2AroundSprocket = 0;
+
     //Calculate motor axes length to the bit
     float Motor1Distance = sqrt(pow((-1*_xCordOfMotor - xTarget),2)+pow((_yCordOfMotor - yTarget),2));
     float Motor2Distance = sqrt(pow((_xCordOfMotor - xTarget),2)+pow((_yCordOfMotor - yTarget),2));
 
     //Calculate the chain angles from horizontal, based on if the chain connects to the sled from the top or bottom of the sprocket
     if(sysSettings.chainOverSprocket == 1){
-        float Chain1Angle = asin((_yCordOfMotor - yTarget)/Motor1Distance) + asin(R/Motor1Distance);
-        float Chain2Angle = asin((_yCordOfMotor - yTarget)/Motor2Distance) + asin(R/Motor2Distance);
+        Chain1Angle = asin((_yCordOfMotor - yTarget)/Motor1Distance) + asin(R/Motor1Distance);
+        Chain2Angle = asin((_yCordOfMotor - yTarget)/Motor2Distance) + asin(R/Motor2Distance);
 
-        float Chain1AroundSprocket = R * Chain1Angle;
-        float Chain2AroundSprocket = R * Chain2Angle;
+        Chain1AroundSprocket = R * Chain1Angle;
+        Chain2AroundSprocket = R * Chain2Angle;
     }
     else{
-        float Chain1Angle = asin((_yCordOfMotor - yTarget)/Motor1Distance) - asin(R/Motor1Distance);
-        float Chain2Angle = asin((_yCordOfMotor - yTarget)/Motor2Distance) - asin(R/Motor2Distance);
+        Chain1Angle = asin((_yCordOfMotor - yTarget)/Motor1Distance) - asin(R/Motor1Distance);
+        Chain2Angle = asin((_yCordOfMotor - yTarget)/Motor2Distance) - asin(R/Motor2Distance);
 
-        float Chain1AroundSprocket = R * (3.14159 - Chain1Angle);
-        float Chain2AroundSprocket = R * (3.14159 - Chain2Angle);
+        Chain1AroundSprocket = R * (3.14159 - Chain1Angle);
+        Chain2AroundSprocket = R * (3.14159 - Chain2Angle);
     }
 
     //Calculate the straight chain length from the sprocket to the bit

--- a/cnc_ctrl_v1/Report.cpp
+++ b/cnc_ctrl_v1/Report.cpp
@@ -164,6 +164,7 @@ void reportMaslowSettings() {
     Serial.print(F("$35=")); Serial.println(sysSettings.zKdV);
     Serial.print(F("$36=")); Serial.println(sysSettings.zPropWeightV);
     Serial.print(F("$37=")); Serial.println(sysSettings.chainSagCorrection);
+    Serial.print(F("$38=")); Serial.println(sysSettings.chainOverSprocket);
   #else
     Serial.print(F("$0=")); Serial.print(sysSettings.machineWidth);
     Serial.print(F(" (machine width, mm, $K)\r\n$1=")); Serial.print(sysSettings.machineHeight);
@@ -201,7 +202,8 @@ void reportMaslowSettings() {
     Serial.print(F(" (z axis Ki Velocity)\r\n$35=")); Serial.print(sysSettings.zKdV);
     Serial.print(F(" (z axis Kd Velocity)\r\n$36=")); Serial.print(sysSettings.zPropWeightV);
     Serial.print(F(" (z axis Velocity proportional weight)\r\n$37=")); Serial.print(sysSettings.chainSagCorrection);
-    Serial.println(F(" (chain sag correction value)"));
+    Serial.print(F(" (chain sag correction value)\r\n$38=")); Serial.print(sysSettings.chainOverSprocket);
+    Serial.println(F(" (chain over sprocket)"));
   #endif
 }
 

--- a/cnc_ctrl_v1/Settings.cpp
+++ b/cnc_ctrl_v1/Settings.cpp
@@ -386,8 +386,10 @@ byte settingsStoreGlobalSetting(const byte& parameter,const float& value){
               sysSettings.chainSagCorrection = value;
               break;
         case 38:
-              sysSettings.chainOverSprocket = value;
-              setupAxes();
+              if (sysSettings.chainOverSprocket != value){
+                  sysSettings.chainOverSprocket = value;
+                  systemReset();
+              }
               break;
         default:
               return(STATUS_INVALID_STATEMENT);

--- a/cnc_ctrl_v1/Settings.cpp
+++ b/cnc_ctrl_v1/Settings.cpp
@@ -103,6 +103,7 @@ void settingsReset() {
     sysSettings.zKdV = 0.28;   // float zKdV;
     sysSettings.zPropWeightV = 1.0;    // float zPropWeightV;
     sysSettings.chainSagCorrection = 0.0;  // float chainSagCorrection;
+    sysSettings.chainOverSprocket = 1;   // byte chainOverSprocket;
     sysSettings.eepromValidData = EEPROMVALIDDATA; // byte eepromValidData;
 }
 
@@ -383,6 +384,10 @@ byte settingsStoreGlobalSetting(const byte& parameter,const float& value){
             break;
         case 37:
               sysSettings.chainSagCorrection = value;
+              break;
+        case 38:
+              sysSettings.chainOverSprocket = value;
+              setupAxes();
               break;
         default:
               return(STATUS_INVALID_STATEMENT);

--- a/cnc_ctrl_v1/Settings.cpp
+++ b/cnc_ctrl_v1/Settings.cpp
@@ -386,10 +386,7 @@ byte settingsStoreGlobalSetting(const byte& parameter,const float& value){
               sysSettings.chainSagCorrection = value;
               break;
         case 38:
-              if (sysSettings.chainOverSprocket != value){
-                  sysSettings.chainOverSprocket = value;
-                  systemReset();
-              }
+              sysSettings.chainOverSprocket = value;
               break;
         default:
               return(STATUS_INVALID_STATEMENT);

--- a/cnc_ctrl_v1/Settings.h
+++ b/cnc_ctrl_v1/Settings.h
@@ -69,6 +69,7 @@ typedef struct {  // I think this is about ~128 bytes in size if I counted corre
   float zKdV;
   float zPropWeightV;
   float chainSagCorrection;
+  byte chainOverSprocket;
   byte eepromValidData;  // This should always be last, that way if an error
                          // happens in writing, it will not be written and we
 } settings_t;            // will know to reset the settings

--- a/cnc_ctrl_v1/System.cpp
+++ b/cnc_ctrl_v1/System.cpp
@@ -151,8 +151,16 @@ void   setupAxes(){
 
 
     }
-    leftAxis.setup (ENC, IN6, IN5, ENCODER3B, ENCODER3A, 'L', LOOPINTERVAL);
-    rightAxis.setup(ENA, IN1, IN2, ENCODER1A, ENCODER1B, 'R', LOOPINTERVAL);
+
+    if(sysSettings.chainOverSprocket == 1){
+        leftAxis.setup (ENC, IN6, IN5, ENCODER3B, ENCODER3A, 'L', LOOPINTERVAL);
+        rightAxis.setup(ENA, IN1, IN2, ENCODER1A, ENCODER1B, 'R', LOOPINTERVAL);
+    }
+    else{
+        leftAxis.setup (ENC, IN5, IN6, ENCODER3A, ENCODER3B, 'L', LOOPINTERVAL);
+        rightAxis.setup(ENA, IN2, IN1, ENCODER1B, ENCODER1A, 'R', LOOPINTERVAL);
+    }
+    
     zAxis.setup    (ENB, IN3, IN4, ENCODER2B, ENCODER2A, 'Z', LOOPINTERVAL);
 }
 

--- a/cnc_ctrl_v1/System.h
+++ b/cnc_ctrl_v1/System.h
@@ -83,6 +83,7 @@ void maslowDelay(unsigned long);
 void  _watchDog();
 void execSystemRealtime();
 void systemSaveAxesPosition();
+void systemReset();
 byte systemExecuteCmdstring(String&);
 
 #endif

--- a/cnc_ctrl_v1/cnc_ctrl_v1.ino
+++ b/cnc_ctrl_v1/cnc_ctrl_v1.ino
@@ -38,8 +38,8 @@ void setup(){
     Serial.print(getPCBVersion());
     Serial.println(F(" Detected"));
     sys.inchesToMMConversion = 1;
-    setupAxes();
     settingsInit();
+    setupAxes();
     // TODO This seems wrong, if the encoder steps are changed, axis position
     // will be in the wrong place.  Would be better if we stored positions as
     // steps 


### PR DESCRIPTION
This adds a configuration setting to select which way the chain wraps around the sprocket to go to the motor. Changes are also made to update the triangular kinematics code. When a new value of chainOverSprocket is received the axes are reconfigured.

Note that this does not update the quadrilateral kinematics, so using quadrilateral kinematics with the chains on bottom of the motor sprockets could lead to accuracy errors.

When a new value of chainOverSprocket is received, setupAxes() is called. I don't think this would cause issues, but wanted to point it out for review.

An associated GroundControl PR will be submitted shortly.