### PR TITLE
Fix bug in storing encoder steps

### DIFF
--- a/cnc_ctrl_v1/Settings.cpp
+++ b/cnc_ctrl_v1/Settings.cpp
@@ -22,12 +22,6 @@ Copyright 2014-2017 Bar Smith*/
 
 #include "Maslow.h"
 
-void settingsInit(){
-    // Do we have any error handling of this?
-    settingsLoadFromEEprom();
-    settingsLoadStepsFromEEprom();
-}
-
 void settingsLoadFromEEprom(){
     /* 
     Loads data from EEPROM if EEPROM data is valid, only called on startup

--- a/cnc_ctrl_v1/Settings.h
+++ b/cnc_ctrl_v1/Settings.h
@@ -87,7 +87,6 @@ typedef struct {
   byte eepromValidData;
 } settingsStepsV1_t;
 
-void settingsInit();
 void settingsLoadFromEEprom();
 void settingsReset();
 void settingsWipe(byte);

--- a/cnc_ctrl_v1/cnc_ctrl_v1.ino
+++ b/cnc_ctrl_v1/cnc_ctrl_v1.ino
@@ -38,8 +38,9 @@ void setup(){
     Serial.print(getPCBVersion());
     Serial.println(F(" Detected"));
     sys.inchesToMMConversion = 1;
-    settingsInit();
+    settingsLoadFromEEprom();
     setupAxes();
+    settingsLoadStepsFromEEprom();
     // TODO This seems wrong, if the encoder steps are changed, axis position
     // will be in the wrong place.  Would be better if we stored positions as
     // steps 


### PR DESCRIPTION
Fix bug where encoder steps are overwritten each time the board is booted up. This is related to the chain on bottom functionality, although the bug occurs whether the chain is on top or bottom.