### PR TITLE
Add PWM frequency to system settings

### DIFF
--- a/cnc_ctrl_v1/Report.cpp
+++ b/cnc_ctrl_v1/Report.cpp
@@ -166,6 +166,7 @@ void reportMaslowSettings() {
     Serial.print(F("$36=")); Serial.println(sysSettings.zPropWeightV, 8);
     Serial.print(F("$37=")); Serial.println(sysSettings.chainSagCorrection, 8);
     Serial.print(F("$38=")); Serial.println(sysSettings.chainOverSprocket);
+    Serial.print(F("$39=")); Serial.println(sysSettings.fPWM);
   #else
     Serial.print(F("$0=")); Serial.print(sysSettings.machineWidth);
     Serial.print(F(" (machine width, mm)\r\n$1=")); Serial.print(sysSettings.machineHeight, 8);
@@ -205,7 +206,9 @@ void reportMaslowSettings() {
     Serial.print(F(" (z axis Kd Velocity)\r\n$36=")); Serial.print(sysSettings.zPropWeightV, 8);
     Serial.print(F(" (z axis Velocity proportional weight)\r\n$37=")); Serial.print(sysSettings.chainSagCorrection, 8);
     Serial.print(F(" (chain sag correction value)\r\n$38=")); Serial.print(sysSettings.chainOverSprocket);
-    Serial.println(F(" (chain over sprocket)"));
+    Serial.print(F(" (chain over sprocket)\r\n$39=")); Serial.print(sysSettings.fPWM);
+    Serial.print(F(" (PWM frequency value 1=39,000Hz, 2=4,100Hz, 3=490Hz)"));
+    Serial.println();
   #endif
 }
 

--- a/cnc_ctrl_v1/Settings.cpp
+++ b/cnc_ctrl_v1/Settings.cpp
@@ -44,6 +44,7 @@ void settingsLoadFromEEprom(){
     }
     
     // Apply settings
+    setPWMPrescalers(int(sysSettings.fPWM));
     kinematics.recomputeGeometry();
     leftAxis.changeEncoderResolution(&sysSettings.encoderSteps);
     rightAxis.changeEncoderResolution(&sysSettings.encoderSteps);
@@ -98,6 +99,7 @@ void settingsReset() {
     sysSettings.zPropWeightV = 1.0;    // float zPropWeightV;
     sysSettings.chainSagCorrection = 0.0;  // float chainSagCorrection;
     sysSettings.chainOverSprocket = 1;   // byte chainOverSprocket;
+    sysSettings.fPWM = 3;   // byte fPWM;
     sysSettings.eepromValidData = EEPROMVALIDDATA; // byte eepromValidData;
 }
 
@@ -380,6 +382,10 @@ byte settingsStoreGlobalSetting(const byte& parameter,const float& value){
               break;
         case 38:
               sysSettings.chainOverSprocket = value;
+              break;
+        case 39:
+              sysSettings.fPWM = value;
+              setPWMPrescalers(value);
               break;
         default:
               return(STATUS_INVALID_STATEMENT);

--- a/cnc_ctrl_v1/Settings.h
+++ b/cnc_ctrl_v1/Settings.h
@@ -71,6 +71,7 @@ typedef struct {  // I think this is about ~128 bytes in size if I counted corre
   float zPropWeightV;
   float chainSagCorrection;
   byte chainOverSprocket;
+  byte fPWM;
   byte eepromValidData;  // This should always be last, that way if an error
                          // happens in writing, it will not be written and we
 } settings_t;            // will know to reset the settings

--- a/cnc_ctrl_v1/Settings.h
+++ b/cnc_ctrl_v1/Settings.h
@@ -20,7 +20,7 @@ Copyright 2014-2017 Bar Smith*/
 #ifndef settings_h
 #define settings_h
 
-#define SETTINGSVERSION 3      // The current version of settings, if this doesn't
+#define SETTINGSVERSION 4      // The current version of settings, if this doesn't
                                // match what is in EEPROM then settings on
                                // machine are reset to defaults
 #define EEPROMVALIDDATA 56     // This is just a random byte value that is used 

--- a/cnc_ctrl_v1/System.cpp
+++ b/cnc_ctrl_v1/System.cpp
@@ -171,6 +171,62 @@ int getPCBVersion(){
     return (8*digitalRead(53) + 4*digitalRead(52) + 2*digitalRead(23) + 1*digitalRead(22)) - 1;
 }
 
+//
+// PWM frequency change
+//  presently just sets the default value
+//  different values seem to need specific PWM tunings...
+//
+void setPWMPrescalers(int prescalerChoice) {
+    #if defined (verboseDebug) && verboseDebug > 0
+        Serial.print(F("fPWM set to "));
+        switch (prescalerChoice) {
+            case 1:
+                Serial.println(F("31,000Hz"));
+            break;
+            case 2:
+                Serial.println(F("4,100Hz"));
+            break;
+            case 3:
+                Serial.println(F("490Hz"));
+            }
+    #endif
+// first must erase the bits in each TTCRxB register that control the timers prescaler
+    int prescalerEraser = 7;      // this is 111 in binary and is used as an eraser
+    TCCR2B &= ~prescalerEraser;   // this operation sets the three bits in TCCR2B to 0
+    TCCR3B &= ~prescalerEraser;   // this operation sets the three bits in TCCR3B to 0
+    TCCR4B &= ~prescalerEraser;   // this operation sets the three bits in TCCR4B to 0
+    // now set those same three bits
+// ————————————————————————————–
+// TIMER 2       (Pin 9, 10)
+// Value  Divisor  Frequency
+// 0x01   1        31.374 KHz
+// 0x02   8        3.921 KHz
+// 0x03   32       980.3 Hz        // don;t use this...
+// 0x04   64       490.1 Hz        // default
+// 0x05   128      245 hz
+// 0x06   256      122.5 hz
+// 0x07   1024     30.63 hz
+// Code:  TCCR2B = (TCCR2B & 0xF8) | value ;
+// —————————————————————————————-
+// Timers 3, 4 ( Pin 2, 3, 5), (Pin 6, 7, 8)
+// 
+// Value  Divisor  Frequency
+// 0x01   1        31.374 KHz
+// 0x02   8        3.921 Khz
+// 0x03   64       490.1 Hz        // default
+// 0x04   256      122.5 Hz
+// 0x05   1024     30.63 Hz
+// Code:  TCCR3B = (TCCR3B & 0xF8) | value ;
+// —————————————————————————————-
+    // and apply it
+    if (prescalerChoice >= 3) {
+      TCCR2B |= (prescalerChoice + 1); // pins 9, 10 - change to match timers3&4
+    } else {
+      TCCR2B |= prescalerChoice; // pins 9, 10
+      }
+    TCCR3B |= prescalerChoice;   // pins 2, 3, 5
+    TCCR4B |= prescalerChoice;   // pins 6, 7, 8
+}
 
 // This should likely go away and be handled by setting the pause flag and then
 // pausing in the execSystemRealtime function

--- a/cnc_ctrl_v1/System.h
+++ b/cnc_ctrl_v1/System.h
@@ -85,5 +85,6 @@ void execSystemRealtime();
 void systemSaveAxesPosition();
 void systemReset();
 byte systemExecuteCmdstring(String&);
+void setPWMPrescalers(int prescalerChoice);
 
 #endif


### PR DESCRIPTION
This builds upon PR #385 and #386 to allow changing the PWM prescaler frequency from GroundControl.

This needs a cooresponding GroundControl PR (GroundControl #619).

 - add a system setting $39 fPWM
 - set the default value to 3 = 490Hz
 - change the prescaler for timers2-4 on change of fPWM
 - report the change if verboseDebug > 0