### PR TITLE
rename 'zAxisAuto'

### DIFF
--- a/cnc_ctrl_v1/Report.cpp
+++ b/cnc_ctrl_v1/Report.cpp
@@ -144,7 +144,7 @@ void reportMaslowSettings() {
     Serial.print(F("$13=")); Serial.println(sysSettings.distPerRot, 8);
     Serial.print(F("$15=")); Serial.println(sysSettings.maxFeed);
     Serial.print(F("$16=")); Serial.println(sysSettings.zAxisAttached);
-    Serial.print(F("$17=")); Serial.println(sysSettings.zAxisAuto);
+    Serial.print(F("$17=")); Serial.println(sysSettings.spindleAutomate);
     Serial.print(F("$18=")); Serial.println(sysSettings.maxZRPM, 8);
     Serial.print(F("$19=")); Serial.println(sysSettings.zDistPerRot, 8);
     Serial.print(F("$20=")); Serial.println(sysSettings.zEncoderSteps, 8);
@@ -184,8 +184,8 @@ void reportMaslowSettings() {
     Serial.print(F(" (main steps per revolution)\r\n$13=")); Serial.print(sysSettings.distPerRot, 8);
     Serial.print(F(" (distance / rotation, mm)\r\n$15=")); Serial.print(sysSettings.maxFeed);
     Serial.print(F(" (max feed, mm/min)\r\n$16=")); Serial.print(sysSettings.zAxisAttached);
-    Serial.print(F(" (Auto Z Axis, 1 = Yes)\r\n$17=")); Serial.print(sysSettings.zAxisAuto);
-    Serial.print(F(" (auto z axis)\r\n$18=")); Serial.print(sysSettings.maxZRPM, 8);
+    Serial.print(F(" (Auto Z Axis, 1 = Yes)\r\n$17=")); Serial.print(sysSettings.spindleAutomate);
+    Serial.print(F(" (auto spindle)\r\n$18=")); Serial.print(sysSettings.maxZRPM, 8);
     Serial.print(F(" (max z axis RPM)\r\n$19=")); Serial.print(sysSettings.zDistPerRot, 8);
     Serial.print(F(" (z axis distance / rotation)\r\n$20=")); Serial.print(sysSettings.zEncoderSteps, 8);
     Serial.print(F(" (z axis steps per revolution)\r\n$21=")); Serial.print(sysSettings.KpPos, 8);

--- a/cnc_ctrl_v1/Report.cpp
+++ b/cnc_ctrl_v1/Report.cpp
@@ -185,7 +185,7 @@ void reportMaslowSettings() {
     Serial.print(F(" (distance / rotation, mm)\r\n$15=")); Serial.print(sysSettings.maxFeed);
     Serial.print(F(" (max feed, mm/min)\r\n$16=")); Serial.print(sysSettings.zAxisAttached);
     Serial.print(F(" (Auto Z Axis, 1 = Yes)\r\n$17=")); Serial.print(sysSettings.spindleAutomate);
-    Serial.print(F(" (auto spindle)\r\n$18=")); Serial.print(sysSettings.maxZRPM, 8);
+    Serial.print(F(" (auto spindle servo/relay)\r\n$18=")); Serial.print(sysSettings.maxZRPM, 8);
     Serial.print(F(" (max z axis RPM)\r\n$19=")); Serial.print(sysSettings.zDistPerRot, 8);
     Serial.print(F(" (z axis distance / rotation)\r\n$20=")); Serial.print(sysSettings.zEncoderSteps, 8);
     Serial.print(F(" (z axis steps per revolution)\r\n$21=")); Serial.print(sysSettings.KpPos, 8);

--- a/cnc_ctrl_v1/Settings.cpp
+++ b/cnc_ctrl_v1/Settings.cpp
@@ -77,7 +77,7 @@ void settingsReset() {
     sysSettings.distPerRot = 63.5;   // float distPerRot;
     sysSettings.maxFeed = 1000;   // int maxFeed;
     sysSettings.zAxisAttached = true;   // zAxisAttached;
-    sysSettings.zAxisAuto = false;  // bool zAxisAuto;
+    sysSettings.spindleAutomate = false;  // bool spindleAutomate;
     sysSettings.maxZRPM = 12.60;  // float maxZRPM;
     sysSettings.zDistPerRot = 3.17;   // float zDistPerRot;
     sysSettings.zEncoderSteps = 7560.0; // float zEncoderSteps;
@@ -293,7 +293,7 @@ byte settingsStoreGlobalSetting(const byte& parameter,const float& value){
               sysSettings.zAxisAttached = value;
               break;
         case 17: 
-              sysSettings.zAxisAuto = value;
+              sysSettings.spindleAutomate = value;
               break;
         case 18: 
               sysSettings.maxZRPM = value;

--- a/cnc_ctrl_v1/Settings.h
+++ b/cnc_ctrl_v1/Settings.h
@@ -49,7 +49,7 @@ typedef struct {  // I think this is about ~128 bytes in size if I counted corre
   float distPerRot;
   unsigned int maxFeed;
   bool zAxisAttached;
-  bool zAxisAuto;
+  bool spindleAutomate;
   float maxZRPM;
   float zDistPerRot;
   float zEncoderSteps;

--- a/cnc_ctrl_v1/Spindle.cpp
+++ b/cnc_ctrl_v1/Spindle.cpp
@@ -23,7 +23,7 @@ void  setSpindlePower(bool powerState) {
     /*
      * Turn spindle on or off depending on powerState
      */ 
-    boolean useServo = !sysSettings.zAxisAuto;
+    boolean useServo = !sysSettings.spindleAutomate;
     boolean activeHigh = true;
     int delayAfterChange = 1000;  // milliseconds
     int servoIdle =  90;  // degrees


### PR DESCRIPTION
PR #328 added a setting to enable/disable spindle control. The setting was named 'zAxisAuto' which seems confusing as it is being used as an on/off control for spindle power. Change the name and accompanying text in Report.cpp to 'spindleAutomation' to better reflect its use. Note that the change in GC that accomanied #328 was PR #458.

This addresses Issue #391, and is accompanied by GC PR #635