### PR TITLE
Initial version of a stalled/unhooked axis detector

### DIFF
--- a/cnc_ctrl_v1/Axis.cpp
+++ b/cnc_ctrl_v1/Axis.cpp
@@ -105,27 +105,30 @@ void   Axis::computePID(){
     if (_pidController.Compute()){
         // Only write output if the PID calculation was performed
         motorGearboxEncoder.write(_pidOutput);
-		
-		if (millis() - stallmillis > STALLTIMEOUT)
-		{
-			stallmillis = millis();
-			
-			long delta=lastcoder - motorGearboxEncoder.encoder.read(); 
-			
-			if(lastcoder == 0 || delta >  STALLSTEPS || delta < STALLSTEPS)
-			{
-				moved=lastcoder !=0;
-				lastcoder = motorGearboxEncoder.encoder.read();
-			}
-			else
-			{
-				stalled=1;
-				stalldelta= delta;
-			}
-		}
-    } else {
-      lastcoder=0;  //We've been deactivated; reset counts
-    }
+
+        if(_pidOutput) {
+            if (millis() - stallmillis > STALLTIMEOUT)
+            {
+                stallmillis = millis();
+                
+                long delta=lastcoder - motorGearboxEncoder.encoder.read(); 
+                
+                if(lastcoder == 0 || delta >  STALLSTEPS || delta < STALLSTEPS)
+                {
+                    moved=lastcoder !=0;
+                    lastcoder = motorGearboxEncoder.encoder.read();
+                }
+                else
+                {
+                    stalled=1;
+                    stalldelta= delta;
+                }
+            }
+        } else {
+            lastcoder=0;  //No motion requested; reset counts
+            stalled=moved=stalldelta=0;
+        }
+    } 
     
     motorGearboxEncoder.computePID();
 }

--- a/cnc_ctrl_v1/Axis.h
+++ b/cnc_ctrl_v1/Axis.h
@@ -53,8 +53,9 @@
             double     pidInput();
             double     pidOutput();
             long  steps();
-			char  moved, stalled;
-			long  stalldelta;
+			bool  moved;        //1 if the axis has ever moved since it's been attached
+            char  stalled;      //+1 every time through the PID loop if the encoder hasn't changed
+			long  stalldelta;   //Debug var keeping track of what the delta was (so we can fine tune STALLSTEPS if it shows up at wrong times.
 			char  name();
 			
         private:

--- a/cnc_ctrl_v1/Axis.h
+++ b/cnc_ctrl_v1/Axis.h
@@ -18,6 +18,9 @@
     #ifndef Axis_h
     #define Axis_h
 
+	#define STALLTIMEOUT	100 //100ms
+	#define STALLSTEPS		10	//Deadband; if it hasn't moved STALLSTEPS in STALLTIMEOUT, the axis is stalled.
+	
     class Axis{
         public:
             void   setup(const int& pwmPin, const int& directionPin1, const int& directionPin2, const int& encoderPin1, const int& encoderPin2, const char& axisName, const unsigned long& loopInterval);
@@ -50,7 +53,10 @@
             double     pidInput();
             double     pidOutput();
             long  steps();
-            
+			char  moved, stalled;
+			long  stalldelta;
+			char  name();
+			
         private:
             int        _PWMread(int pin);
             void       _writeFloat(const unsigned int& addr, const float& x);
@@ -66,5 +72,5 @@
             bool       _disableAxisForTesting = false;
             char       _axisName;
     };
-
+	
     #endif

--- a/cnc_ctrl_v1/Motion.cpp
+++ b/cnc_ctrl_v1/Motion.cpp
@@ -133,7 +133,7 @@ int   coordinatedMove(const float& xEnd, const float& yEnd, const float& zEnd, f
         #if misloopDebug > 0
         inMovementLoop = true;
         #endif
-        //if last movment was performed start the next
+        //if last movement was performed start the next
         if (!movementUpdated) {
             //find the target point for this step
             // This section ~20us

--- a/cnc_ctrl_v1/Report.cpp
+++ b/cnc_ctrl_v1/Report.cpp
@@ -236,7 +236,20 @@ void  returnPoz(){
     static unsigned long lastRan = millis();
     
     if (millis() - lastRan > POSITIONTIMEOUT){
+        char tmpbuf[80], buflen=0;
+        memset(tmpbuf, 0, sizeof(tmpbuf));
         
+        for (int i=0;i<3;i++){
+            if(axes[i].stalled > 5){
+                buflen+=snprintf(tmpbuf+buflen, sizeof(tmpbuf)-buflen, "%c %s ", axes[i].name(), (axes[i].moved > 5) ? F("STALL") : F("UNHK "));
+            }
+        }
+        
+        if(buflen>0){
+            Serial.print(F("Message: "));
+            Serial.println(tmpbuf);
+            pause();    //Which should unattach the axes, which should clear the error.
+        }
         
         Serial.print(F("<Idle,MPos:"));
         Serial.print(sys.xPosition/sys.inchesToMMConversion);

--- a/cnc_ctrl_v1/Report.cpp
+++ b/cnc_ctrl_v1/Report.cpp
@@ -226,6 +226,7 @@ void  returnError(){
         Serial.println(F("]"));
 }
 
+char tmpbuf[80];
 void  returnPoz(){
     /*
     Causes the machine's position (x,y) to be sent over the serial connection updated on the UI
@@ -236,17 +237,22 @@ void  returnPoz(){
     static unsigned long lastRan = millis();
     
     if (millis() - lastRan > POSITIONTIMEOUT){
-        char tmpbuf[80], buflen=0;
-        memset(tmpbuf, 0, sizeof(tmpbuf));
+        char buflen=0;
         
-        for (int i=0;i<3;i++){
-            if(axes[i].stalled > 5){
-                buflen+=snprintf(tmpbuf+buflen, sizeof(tmpbuf)-buflen, "%c %s ", axes[i].name(), (axes[i].moved > 5) ? F("STALL") : F("UNHK "));
+        for (int i=0;i<3;i++){          //For each axis (A,B,z)
+            if(axes[i]->stalled > 5){    //If it's been stalled for at least 5 passes through the PID loop
+                if(buflen==0)
+                    memset(tmpbuf, 0, sizeof(tmpbuf));  //Clear the buffer if this is the first axis that was stalled.
+                buflen+=snprintf(tmpbuf+buflen, 
+                    sizeof(tmpbuf)-buflen, "%c %s [%d] ",              //Format a message:
+                    axes[i]->name(),                                     //Axis Name
+                    (axes[i]->moved) ? F("STALLED ") : F("UNHOOKED "),   //If it has ever moved, "Stalled", otherwise, "Unhooked
+                    axes[i]->stalldelta);                                //Debug var: the stall delta (bigger indicates last stall it was told to move a lot, but didn't
             }
         }
         
         if(buflen>0){
-            Serial.print(F("Message: "));
+            Serial.print(F("ALARM: "));
             Serial.println(tmpbuf);
             pause();    //Which should unattach the axes, which should clear the error.
         }

--- a/cnc_ctrl_v1/System.h
+++ b/cnc_ctrl_v1/System.h
@@ -53,7 +53,7 @@ typedef struct {
   bool stop;                  // Stop flag.
   byte state;                 // State tracking flag
   byte pause;                 // Pause flag.
-  float xPosition;            // Cartessian position of XY axes
+  float xPosition;            // Cartesian position of XY axes
   float yPosition;            // Cached because calculating position is intensive
   float steps[3];             // Encoder position of axes
   bool  useRelativeUnits;     // 
@@ -71,6 +71,7 @@ extern system_t sys;
 extern Axis leftAxis;
 extern Axis rightAxis;
 extern Axis zAxis;
+extern Axis axes[3];
 extern RingBuffer incSerialBuffer;
 extern Kinematics kinematics;
 extern byte systemRtExecAlarm;

--- a/cnc_ctrl_v1/System.h
+++ b/cnc_ctrl_v1/System.h
@@ -71,7 +71,7 @@ extern system_t sys;
 extern Axis leftAxis;
 extern Axis rightAxis;
 extern Axis zAxis;
-extern Axis axes[3];
+extern Axis *axes[3];
 extern RingBuffer incSerialBuffer;
 extern Kinematics kinematics;
 extern byte systemRtExecAlarm;

--- a/cnc_ctrl_v1/cnc_ctrl_v1.ino
+++ b/cnc_ctrl_v1/cnc_ctrl_v1.ino
@@ -27,7 +27,7 @@ byte systemRtExecAlarm;
 Axis leftAxis;
 Axis rightAxis;
 Axis zAxis;
-Axis axes[3] = {leftAxis, rightAxis, zAxis};
+Axis *axes[3] = {&leftAxis, &rightAxis, &zAxis};
 
 // Define kinematics, is it necessary for this to be a class?  Is this really
 // going to be reused?

--- a/cnc_ctrl_v1/cnc_ctrl_v1.ino
+++ b/cnc_ctrl_v1/cnc_ctrl_v1.ino
@@ -27,6 +27,7 @@ byte systemRtExecAlarm;
 Axis leftAxis;
 Axis rightAxis;
 Axis zAxis;
+Axis axes[3] = {leftAxis, rightAxis, zAxis};
 
 // Define kinematics, is it necessary for this to be a class?  Is this really
 // going to be reused?
@@ -50,7 +51,7 @@ void setup(){
     Timer1.initialize(LOOPINTERVAL);
     Timer1.attachInterrupt(runsOnATimer);
     
-    Serial.println(F("Grbl v1.00"));  // Why GRBL?  Apparenlty because some programs are silly and look for this as an initailization command
+    Serial.println(F("Grbl v1.00"));  // Why GRBL?  Apparently because some programs are silly and look for this as an initialization command
     Serial.println(F("ready"));
     reportStatusMessage(STATUS_OK);
 }


### PR DESCRIPTION
For issue #378, but **this needs testing** (I wrote it on a plane flight and I won't be back to carving until Mar 6).

Algorithm (and if this is not clear from the patch, let me know and I'll throw in some more comments):
1. When calculating the position PID for each axis:  if it moved since last time, increment `moved`, if not, increment `stalled`.
2. If an axis is detached, clear both variables.
3. When the report runs, examine all axes; if it has stalled for >5 cycles (so 500ms), prepare a message:
3b. If it's moved before, say it's stalled.  If it hasn't moved before, say it's UNHK'd
4. If I have a message from step 3, `pause()` the machine (which hopefully detaches the axes which will clear the error)

Not sure about step 4 happening fast enough... maybe I need to put a "if not paused" around the block in `report.cpp`?
