### PR TITLE
Add a PlatformIO project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,10 +3,13 @@
 .clang_complete
 .gcc-flags.json
 .travis.yml
-platformio.ini
 lib/readme.txt
 cnc_ctrl_v1/.DS_Store
 cnc_ctrl_v1/.DS_Store
 cnc_ctrl_v1/.DS_Store
 .DS_Store
 **/.DS_Store
+.vscode/
+.vscode/c_cpp_properties.json
+.vscode/launch.json
+simduino_atmega2560_flash.bin

--- a/guestBook.txt
+++ b/guestBook.txt
@@ -32,3 +32,5 @@ seware74 - When 900 years old, you reach… Look as good, you will not. Hmm. - 5
 ladams00 - Can't wait for Maslow to show up at my door! Jan 7th 2018
 
 Bar - Back to update the how to contribute page for the new look of GitHub :)
+
+I'm Batman.

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,25 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; http://docs.platformio.org/page/projectconf.html
+
+[platformio]
+src_dir = cnc_ctrl_v1
+
+[env:megaatmega2560]
+platform = atmelavr
+board = megaatmega2560
+framework = arduino
+
+[env:simavr]
+platform = atmelavr
+board = megaatmega2560
+framework = arduino
+extra_scripts = simavr_env_for_platformio.py
+build_unflags = -Os
+build_flags = -g -O0

--- a/simavr_env_for_platformio.py
+++ b/simavr_env_for_platformio.py
@@ -1,0 +1,12 @@
+Import('env')
+
+#
+# Dump build environment (for debug)
+# print env.Dump()
+#
+
+env.Append(
+  LINKFLAGS=[
+      "-g"
+  ]
+)


### PR DESCRIPTION
This project builds for two environments:
megaatmega2560: This is the standard Arduino Mega 2560 setup for
PlatformIO. It uses the default flags for PlatformIO, and builds an
optimized, stripped binary. Good for building firmware for production
use.
simavr: Disable all optimizations, leave debugging symbols, and #define
SIMAVR. SIMAVR doesn't do anything yet, but it will enable some
simavr-specific behavior in a separate commit.

I created this project as prep for #363, but it can also help simplify
setup for users of the PlatformIO IDE, or someone setting up a CI
environment.

I think it also resolves #365.