### PR TITLE
Add support for running in simavr

### DIFF
--- a/cnc_ctrl_v1/Config.h
+++ b/cnc_ctrl_v1/Config.h
@@ -29,6 +29,9 @@
                            // a servo updating the encoder steps even if no servo
                            // is connected.  Useful for testing on an arduino only
 
+// #define SIMAVR          // Uncomment this if you plan to run the Firmware in the simavr
+                           // simulator. Normally, you would not define this directly, but
+                           // use PlatformIO to build the simavr environment.
 
 #define LOOPINTERVAL 10000 // What is the frequency of the PID loop in microseconds
 

--- a/cnc_ctrl_v1/Maslow.h
+++ b/cnc_ctrl_v1/Maslow.h
@@ -48,5 +48,6 @@
 #include "Settings.h"
 #include "NutsAndBolts.h"
 #include "System.h"
+#include "SimavrSerial.h"
 
 #endif

--- a/cnc_ctrl_v1/SimavrSerial.cpp
+++ b/cnc_ctrl_v1/SimavrSerial.cpp
@@ -1,0 +1,27 @@
+#include "SimavrSerial.h"
+
+#ifdef Serial
+#undef Serial
+#endif
+
+SimavrSerial_ SimavrSerial;
+
+size_t SimavrSerial_::write(uint8_t c)
+{
+    size_t n = Serial.write(c);
+    Serial.flush();
+
+    return n;
+}
+
+void SimavrSerial_::begin(unsigned long baud) {
+    Serial.begin(baud);
+}
+
+int SimavrSerial_::available() {
+    return Serial.available();
+}
+
+int SimavrSerial_::read() {
+    return Serial.read();
+}

--- a/cnc_ctrl_v1/SimavrSerial.h
+++ b/cnc_ctrl_v1/SimavrSerial.h
@@ -1,0 +1,32 @@
+#include "Maslow.h"
+
+#ifndef SimavrSerial_h_
+#define SimavrSerial_h_
+
+#ifdef SIMAVR
+#define Serial SimavrSerial
+#endif
+
+// This class is a wrapper around Serial, to be used when running in the simavr simulator
+// (https://github.com/buserror/simavr)
+//
+// Simavr's UART seems to lock up and crash when you write more than a few characters to it.
+// SimavrSerial works around this issue by flushing after every single character. On a real
+// controller, this might cause a performance issue, so this class is only used if SIMAVR is defined.
+// If SIMAVR is defined, though, any reference to Serial is replaces to a reference to SimavrSerial.
+// This means that every Serial method that is used in our code also needs a wrapper in SimavrSerial,
+// of the simavr environment will not compile.
+//
+// Not the cleanest thing ever, but it's the best I could come up with that 
+// will have zero impact on the actual production code.
+class SimavrSerial_ : public Print
+{
+    public:
+    virtual size_t write(uint8_t);
+    virtual int available();
+    virtual int read();
+    void begin(unsigned long baud);
+};
+
+extern SimavrSerial_ SimavrSerial;
+#endif

--- a/cnc_ctrl_v1/cnc_ctrl_v1.ino
+++ b/cnc_ctrl_v1/cnc_ctrl_v1.ino
@@ -47,8 +47,12 @@ void setup(){
     zAxis.write(zAxis.read());
     readyCommandString.reserve(INCBUFFERLENGTH);           //Allocate memory so that this string doesn't fragment the heap as it grows and shrinks
     gcodeLine.reserve(INCBUFFERLENGTH);
+
+    #ifndef SIMAVR // Using the timer will crash simavr, so we disable it.
+                   // Instead, we'll run runsOnATimer periodically in loop().
     Timer1.initialize(LOOPINTERVAL);
     Timer1.attachInterrupt(runsOnATimer);
+    #endif
     
     Serial.println(F("Grbl v1.00"));  // Why GRBL?  Apparenlty because some programs are silly and look for this as an initailization command
     Serial.println(F("ready"));
@@ -83,7 +87,9 @@ void loop(){
                                  // limit
     while (!sys.stop){
         gcodeExecuteLoop();
-        
+        #ifdef SIMAVR // Normally, runsOnATimer() will, well, run on a timer. See also setup().
+        runsOnATimer();
+        #endif
         execSystemRealtime();
     }
 }


### PR DESCRIPTION
Simavr is a simulator for the AVR family of microcontrollers
(https://github.com/buserror/simavr). Running Maslow firmware in simavr
is useful for automated testing in a CI loop and debugging in GDB.

This is the next step in #363.

These commit works around two issues with simavr:
1. The simulated UART crashes if you don't flush often, so we flush
after every character written to Serial.
2. Our TimerOne class causes the simulator to hang, so I moved the call
to runsOnATimer() into loop(). This means runsOnATimer() will be called
less frequently, but I think that's OK for the simulated environment.
