### PR TITLE
WIP: Disable uploading for simavr

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -23,3 +23,4 @@ framework = arduino
 extra_scripts = simavr_env_for_platformio.py
 build_unflags = -Os
 build_flags = -g -O0
+upload_port = /dev/null

--- a/platformio.ini
+++ b/platformio.ini
@@ -23,4 +23,3 @@ framework = arduino
 extra_scripts = simavr_env_for_platformio.py
 build_unflags = -Os
 build_flags = -g -O0
-upload_port = /dev/null

--- a/simavr_env_for_platformio.py
+++ b/simavr_env_for_platformio.py
@@ -1,12 +1,11 @@
 Import('env')
 
-#
-# Dump build environment (for debug)
-# print env.Dump()
-#
-
+# Run the linker with "-g", to prevent stripping of debugging symbols
 env.Append(
   LINKFLAGS=[
       "-g"
   ]
 )
+
+# Don't try to upload the firmware
+env.Replace(UPLOADHEXCMD="echo Upload is not supported for ${PIOENV}. Skipping")


### PR DESCRIPTION
NOTE: This is not fully tested, and is being uploaded for @blurfl to
take a look.

My previous commit created a PlatformIO project that built a customised
binary for running in simavr. It also attempted to upload this binary
when an Arduino was plugged in, which was never intended.

This commit disables the uploading for simavr.

Other environments