### PR TITLE
Disable builds for Teensy boards

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -24,14 +24,14 @@ extra_scripts = platformio/simavr_env.py
 build_unflags = -Os 
 build_flags = -g -O0 -DSIMAVR -DFAKE_SERVO
 
-[env:teensy36]
-platform = teensy
-board = teensy36
-framework = arduino
-extra_scripts = platformio/teensy_env.py
+;[env:teensy36]
+;platform = teensy
+;board = teensy36
+;framework = arduino
+;extra_scripts = platformio/teensy_env.py
 
-[env:teensy35]
-platform = teensy
-board = teensy35
-framework = arduino
-extra_scripts = platformio/teensy_env.py
+;[env:teensy35]
+;platform = teensy
+;board = teensy35
+;framework = arduino
+;extra_scripts = platformio/teensy_env.py


### PR DESCRIPTION
I accidentally mixed a change that was meant for everyone, with a change
I created for @blurfl to test, and now if anyone tries to use the
PlatformIO project, it will try to build a Teensy version of the code,
which won't work with the current tip of master.