### PR TITLE
Add integration with Travis-CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 .piolibdeps
 .clang_complete
 .gcc-flags.json
-.travis.yml
 lib/readme.txt
 cnc_ctrl_v1/.DS_Store
 cnc_ctrl_v1/.DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,35 @@
+# Continuous Integration (CI) is the practice, in software
+# engineering, of merging all developer working copies with a shared mainline
+# several times a day < http://docs.platformio.org/page/ci/index.html >
+#
+# Documentation:
+#
+# * Travis CI Embedded Builds with PlatformIO
+#   < https://docs.travis-ci.com/user/integration/platformio/ >
+#
+# * PlatformIO integration with Travis CI
+#   < http://docs.platformio.org/page/ci/travis.html >
+#
+# * User Guide for `platformio ci` command
+#   < http://docs.platformio.org/page/userguide/cmd_ci.html >
+#
+#
+# Please choice one of the following templates (proposed below) and uncomment
+# it (remove "# " before each line) or use own configuration according to the
+# Travis CI documentation (see above).
+#
+
+
+#
+# Template #1: General project. Test it using existing `platformio.ini`.
+#
+
+language: python
+python:
+    - "2.7"
+
+install:
+    - pip install -U platformio
+
+script:
+    - platformio run

--- a/platformio.ini
+++ b/platformio.ini
@@ -24,14 +24,14 @@ extra_scripts = platformio/simavr_env.py
 build_unflags = -Os 
 build_flags = -g -O0 -DSIMAVR -DFAKE_SERVO
 
-[env:teensy36]
-platform = teensy
-board = teensy36
-framework = arduino
-extra_scripts = platformio/teensy_env.py
+;[env:teensy36]
+;platform = teensy
+;board = teensy36
+;framework = arduino
+;extra_scripts = platformio/teensy_env.py
 
-[env:teensy35]
-platform = teensy
-board = teensy35
-framework = arduino
-extra_scripts = platformio/teensy_env.py
+;[env:teensy35]
+;platform = teensy
+;board = teensy35
+;framework = arduino
+;extra_scripts = platformio/teensy_env.py


### PR DESCRIPTION
If the project is connected to Travis CI, it will detect any new commit and PR, and run a set of tests on it.

Right now, it just compiles the code for all supported boards (currently Ardumega and simavr, but I hear Teensy is in the works), and confirm that the code compiles. Once we have some automated tests in place, it can also run them.

Later on, this can also be used to automatically upload released binaries to GitHub, but I don't think we're there yet.

Once the build is done, Travis will update GitHub to show the status of PRs and branches. This is what it looks like in my forked project:
![travis_ci_by_idoc_ _pull_request__1_ _idoc_firmware](https://user-images.githubusercontent.com/1854995/36565878-a41562e8-17d6-11e8-9e54-1c7bfe257d88.jpg)
and
![branches_ _idoc_firmware](https://user-images.githubusercontent.com/1854995/36565883-a81a739c-17d6-11e8-8732-9a7b86f82a1c.jpg)

@BarbourSmith, I don't know if you have bandwidth to look at hooking up the main project to CI at this point, but I think this can be useful to merge for other contributors. With this in place, anybody can connect Travis to their forked projects with just a few clicks.