### PR TITLE
Setup Axes Again After Changing Chain Rotation Direction

### DIFF
--- a/cnc_ctrl_v1/Settings.cpp
+++ b/cnc_ctrl_v1/Settings.cpp
@@ -382,6 +382,13 @@ byte settingsStoreGlobalSetting(const byte& parameter,const float& value){
               break;
         case 38:
               sysSettings.chainOverSprocket = value;
+              setupAxes();
+              settingsLoadStepsFromEEprom();
+              // Set initial desired position of the machine to its current position
+              leftAxis.write(leftAxis.read());
+              rightAxis.write(rightAxis.read());
+              zAxis.write(zAxis.read());
+              kinematics.init();
               break;
         case 39:
               sysSettings.fPWM = value;


### PR DESCRIPTION
Means we don't have to restart.