### PR TITLE
Lower the max feedrate 

### DIFF
--- a/cnc_ctrl_v1/GCode.cpp
+++ b/cnc_ctrl_v1/GCode.cpp
@@ -660,7 +660,7 @@ int   G1(const String& readString, int G0orG1){
     }
     else{
         //if this is a rapid move
-        coordinatedMove(xgoto, ygoto, zgoto, 1000); //move the same as a regular move, but go fast
+        coordinatedMove(xgoto, ygoto, zgoto, 600); //move the same as a regular move, but go fast
     }
 }
 

--- a/cnc_ctrl_v1/GCode.cpp
+++ b/cnc_ctrl_v1/GCode.cpp
@@ -660,7 +660,7 @@ int   G1(const String& readString, int G0orG1){
     }
     else{
         //if this is a rapid move
-        coordinatedMove(xgoto, ygoto, zgoto, 600); //move the same as a regular move, but go fast
+        coordinatedMove(xgoto, ygoto, zgoto, sysSettings.maxFeed); //move the same as a regular move, but go fast
     }
 }
 

--- a/cnc_ctrl_v1/Settings.cpp
+++ b/cnc_ctrl_v1/Settings.cpp
@@ -75,7 +75,7 @@ void settingsReset() {
     sysSettings.originalChainLength = 1650;   // int originalChainLength;
     sysSettings.encoderSteps = 8113.7; // float encoderSteps;
     sysSettings.distPerRot = 63.5;   // float distPerRot;
-    sysSettings.maxFeed = 1000;   // int maxFeed;
+    sysSettings.maxFeed = 900;   // int maxFeed;
     sysSettings.zAxisAttached = true;   // zAxisAttached;
     sysSettings.spindleAutomate = false;  // bool spindleAutomate;
     sysSettings.maxZRPM = 12.60;  // float maxZRPM;

--- a/cnc_ctrl_v1/Settings.cpp
+++ b/cnc_ctrl_v1/Settings.cpp
@@ -75,7 +75,7 @@ void settingsReset() {
     sysSettings.originalChainLength = 1650;   // int originalChainLength;
     sysSettings.encoderSteps = 8113.7; // float encoderSteps;
     sysSettings.distPerRot = 63.5;   // float distPerRot;
-    sysSettings.maxFeed = 900;   // int maxFeed;
+    sysSettings.maxFeed = 700;   // int maxFeed;
     sysSettings.zAxisAttached = true;   // zAxisAttached;
     sysSettings.spindleAutomate = false;  // bool spindleAutomate;
     sysSettings.maxZRPM = 12.60;  // float maxZRPM;


### PR DESCRIPTION
It seems like we may have an issue where the motors can't keep up with the maximum feed rate under some circumstances. 

We've seen several reports in the forums, and I just encountered one where during the calibration process the machine started to lower the z-axis before arriving at it's destination because it couldn't keep up.

This PR lowers the maximum feed rate to 700mm/min and sets the G0 rapid moves to use the same value as the maximum feed rate in settings.