### PR TITLE
gcc warnings Part II

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -22,7 +22,7 @@ board = megaatmega2560
 framework = arduino
 extra_scripts = platformio/simavr_env.py
 build_unflags = -Os 
-build_flags = -g -O0 -DSIMAVR -DFAKE_SERVO
+build_flags = -Wall -g -O0 -DSIMAVR -DFAKE_SERVO
 monitor_port = /tmp/simavr-uart0
 
 ;[env:teensy36]


### PR DESCRIPTION
Hmmm, 
maybe I was a bit hasty immediately deleting the last pull requests branch.
I had another thought about your proposal to include the warnings into the Travis build. You're right, it would be a good move. So I had a look at it. Travis just starts a platformIO build and I haven't been in touch with that yet. But on a second glance the next step seems obvious.

--- platformio.ini      2018-03-22 01:35:44.031037400 +0100
+++ platformio.ini   2018-03-22 01:35:44.031037500 +0100
@@ -22,7 +22,7 @@
 framework = arduino
 extra_scripts = platformio/simavr_env.py
 build_unflags = -Os
-build_flags = -g -O0 -DSIMAVR -DFAKE_SERVO
+build_flags = -Wall -g -O0 -DSIMAVR -DFAKE_SERVO
 monitor_port = /tmp/simavr-uart0

I think it is important to deny Travis reporting success if warnings occur during build and  I don't know how or if I even manually have to get Travis to report popped up warnings. With a bit of luck this will work from scratch.