### PR TITLE
gcc warnings Part III

### DIFF
--- a/cnc_ctrl_v1/Axis.cpp
+++ b/cnc_ctrl_v1/Axis.cpp
@@ -85,7 +85,6 @@ void   Axis::setSteps(const long& steps){
 void   Axis::computePID(){
     
     #ifdef FAKE_SERVO
-      static unsigned long lastPrint = millis();
       if (motorGearboxEncoder.motor.attached()){
         // Adds up to 10% error just to simulate servo noise
         double rpm = (-1 * _pidOutput) * random(90, 110) / 100;

--- a/platformio.ini
+++ b/platformio.ini
@@ -22,7 +22,7 @@ board = megaatmega2560
 framework = arduino
 extra_scripts = platformio/simavr_env.py
 build_unflags = -Os 
-build_flags = -Wall -g -O0 -DSIMAVR -DFAKE_SERVO
+build_flags = -g -O0 -DSIMAVR -DFAKE_SERVO
 monitor_port = /tmp/simavr-uart0
 
 ;[env:teensy36]


### PR DESCRIPTION
The (hopefully) final pull request regarding this issue.

Platformio build does not benefit from activating compiler warnings, since it triggers a lot of them in board libray code by the disabled compiler optimization. So, switching them on is reverted.

Another unused Variable was found and deleted.

That's it, folks! :)