### PR TITLE
Reword chain position not found popup

### DIFF
--- a/cnc_ctrl_v1/Kinematics.cpp
+++ b/cnc_ctrl_v1/Kinematics.cpp
@@ -293,7 +293,7 @@ void  Kinematics::forward(const float& chainALength, const float& chainBLength, 
                 Serial.print(chainALength);
                 Serial.print(", ");
                 Serial.print(chainBLength);
-                Serial.println(F(" . Please calibrate chain lengths."));
+                Serial.println(F(" . Please set the chains to a known length (Actions -> Set Chain Lengths)"));
                 *xPos = 0;
                 *yPos = 0;
             }


### PR DESCRIPTION
The popup which displays when a valid position cannot be found for the given chain lengths has a poor choice of words with the word "calibrate" which is a word we use to mean something else. This changes the wording to be more clear