### PR TITLE
Add an alarm for gcode calculation error

### DIFF
--- a/cnc_ctrl_v1/Motion.cpp
+++ b/cnc_ctrl_v1/Motion.cpp
@@ -225,6 +225,9 @@ void  singleAxisMove(Axis* axis, const float& endPos, const float& MMPerMin){
     
 }
 
+// return the sign of the parameter
+int sign(double x) { return x<0 ? -1 : 1; }
+
 // why does this return anything
 int   arc(const float& X1, const float& Y1, const float& X2, const float& Y2, const float& centerX, const float& centerY, const float& MMPerMin, const float& direction){
     /*
@@ -256,6 +259,14 @@ int   arc(const float& X1, const float& Y1, const float& X2, const float& Y2, co
         }
     }
     
+    if (sign(theta) != sign(direction)) {
+      // There is a parameter error in this line of gcode
+      // post an alarm which will wait for user decision about 'Stop' or 'Resume'
+      // if we return, change theta to make the line inoperative and continue to cut
+      reportAlarmMessage(ALARM_GCODE_PARAM_ERROR);
+      theta = 0;
+    }
+
     float arcLengthMM            =  circumference * (theta / (2*pi) );
     
     //set up variables for movement

--- a/cnc_ctrl_v1/Report.cpp
+++ b/cnc_ctrl_v1/Report.cpp
@@ -116,8 +116,15 @@ void  reportAlarmMessage(byte alarm_code) {
     Serial.println(alarm_code);
   #else
     switch (alarm_code) {
-      case ALARM_POSITION_LOST:
-      Serial.println(F("Position Lost")); break;
+      case ALARM_POSITION_LOST: {
+        Serial.println(F("Position Lost")); break;
+        }
+      case ALARM_GCODE_PARAM_ERROR: {
+        Serial.println(F("There is a parameter error in this line of Gcode - make a note of the line number. Cutting will be put on hold until you choose whether to 'Resume Cut' (skipping this line) or 'Stop'.   "));
+        pause(); //This pause() waits for user acknowledgement of message
+        pause(); //Now wait for user decision about 'Stop' or 'Resume'
+        break;
+        }
     }
   #endif
 }

--- a/cnc_ctrl_v1/Report.h
+++ b/cnc_ctrl_v1/Report.h
@@ -58,6 +58,7 @@ Copyright 2014-2017 Bar Smith*/
 
 // Define Maslow alarm codes.
 #define ALARM_POSITION_LOST bit(0)
+#define ALARM_GCODE_PARAM_ERROR bit(1)
 
 // Define Maslow feedback message codes. Valid values (0-255).
 #define MESSAGE_CRITICAL_EVENT 1
@@ -75,6 +76,7 @@ Copyright 2014-2017 Bar Smith*/
 void  reportStatusMessage(byte);
 void  reportFeedbackMessage(byte);
 void  reportMaslowSettings();
+void  reportAlarmMessage(byte);
 void  returnError();
 void  returnPoz();
 void  reportMaslowHelp();


### PR DESCRIPTION
Add flag ALARM_GCODE_PARAM_ERROR and the code to handle it in Report.cpp
Use that flag in Motion.cpp if a parameter value error causes a calculation error when calculating an arc() as used by G2() in GCode.cpp
 Addresses Issue #426, and requires GC PR #697 for the alarm to trigger a dialog. The dialog:

![alarm dialog](https://user-images.githubusercontent.com/1851315/38754388-7b2ba22c-3f16-11e8-8958-cf730277cd78.jpg)

This .nc file will trigger the calculation error when the firmware evaluates line 31. 
[G2-G3-error-arises-in-line-31.nc.zip](https://github.com/MaslowCNC/Firmware/files/1908700/G2-G3-error-arises-in-line-31.nc.zip)

