### PR TITLE
Add a system setting for positionErrorLimit, stop cutting if reached

### DIFF
--- a/cnc_ctrl_v1/Report.h
+++ b/cnc_ctrl_v1/Report.h
@@ -59,6 +59,7 @@ Copyright 2014-2017 Bar Smith*/
 // Define Maslow alarm codes.
 #define ALARM_POSITION_LOST bit(0)
 #define ALARM_GCODE_PARAM_ERROR bit(1)
+#define ALARM_POSITION_LIMIT_ERROR bit(2)
 
 // Define Maslow feedback message codes. Valid values (0-255).
 #define MESSAGE_CRITICAL_EVENT 1

--- a/cnc_ctrl_v1/Settings.cpp
+++ b/cnc_ctrl_v1/Settings.cpp
@@ -405,6 +405,9 @@ byte settingsStoreGlobalSetting(const byte& parameter,const float& value){
               rightAxis.changePitch(&sysSettings.distPerRotRightChainTolerance);
               kinematics.RrightChainTolerance = (sysSettings.distPerRotRightChainTolerance)/(2.0 * 3.14159);
               break;
+        case 42:
+              sysSettings.positionErrorLimit = value;
+              break;
         default:
               return(STATUS_INVALID_STATEMENT);
     }

--- a/cnc_ctrl_v1/Settings.cpp
+++ b/cnc_ctrl_v1/Settings.cpp
@@ -103,6 +103,7 @@ void settingsReset() {
     sysSettings.fPWM = 3;   // byte fPWM;
     sysSettings.distPerRotLeftChainTolerance = 63.5;    // float distPerRotLeftChainTolerance;
     sysSettings.distPerRotRightChainTolerance = 63.5;    // float distPerRotRightChainTolerance;
+    sysSettings.positionErrorLimit = 2.0;  // float positionErrorLimit;
     sysSettings.eepromValidData = EEPROMVALIDDATA; // byte eepromValidData;
 }
 

--- a/cnc_ctrl_v1/Settings.h
+++ b/cnc_ctrl_v1/Settings.h
@@ -74,6 +74,7 @@ typedef struct {  // I think this is about ~128 bytes in size if I counted corre
   byte fPWM;
   float distPerRotLeftChainTolerance;
   float distPerRotRightChainTolerance;
+  float positionErrorLimit;
   byte eepromValidData;  // This should always be last, that way if an error
                          // happens in writing, it will not be written and we
 } settings_t;            // will know to reset the settings


### PR DESCRIPTION
After each time that position error is reported, check against a limit and take action if the limit is reached.

 - add $42 positionErrorLimit with a default of 2mm
 - check each time [PE: is sent
 - set sys.stop flag if left- or right-axis error >= positionErrorLimit

Note, this leaves GC with a 'Hold' in place rather than a 'Stop'. This leaves the line number visible.The user is asked to click the 'Stop' button to get GC into the same state as the firmware.

GC PR #703 makes an Advanced Setting available to change the value of positionErrorLimit.