### PR TITLE
Replace G2/G3 line with equivalent G1 line

### DIFF
--- a/cnc_ctrl_v1/Motion.cpp
+++ b/cnc_ctrl_v1/Motion.cpp
@@ -263,7 +263,7 @@ int   arc(const float& X1, const float& Y1, const float& X2, const float& Y2, co
             theta -= 2*pi;
         }
     }
-    if ((sign(theta) != sign(direction)) || (abs(chordHeight) < .01)) {
+    if ((sign(theta) != sign(direction)) || ((abs(chordHeight) < .01) && (abs(theta) < 0.5))) {
       // There is a parameter error in this line of gcode, either in the size of the angle calculated
       //  or the chord height of the arc between the starting and ending points
       // In either case, the gcode cut was essentially a straight line, so 

--- a/cnc_ctrl_v1/Motion.cpp
+++ b/cnc_ctrl_v1/Motion.cpp
@@ -245,6 +245,11 @@ int   arc(const float& X1, const float& Y1, const float& X2, const float& Y2, co
     float startingAngle          =  atan2(Y1 - centerY, X1 - centerX);
     float endingAngle            =  atan2(Y2 - centerY, X2 - centerX);
     
+    // compute chord height of arc
+    float chordSquared           = sqrt(sq(X2 - X1) + sq(Y2 - Y1));
+    float tau                    = sqrt( sq(radius) - (chordSquared/4.0));
+    float chordHeight            = radius - tau;
+
     //compute angle between lines
     float theta                  =  endingAngle - startingAngle;
     if (direction == COUNTERCLOCKWISE){
@@ -258,13 +263,16 @@ int   arc(const float& X1, const float& Y1, const float& X2, const float& Y2, co
             theta -= 2*pi;
         }
     }
-    
-    if (sign(theta) != sign(direction)) {
-      // There is a parameter error in this line of gcode
-      // post an alarm which will wait for user decision about 'Stop' or 'Resume'
-      // if we return, change theta to make the line inoperative and continue to cut
-      reportAlarmMessage(ALARM_GCODE_PARAM_ERROR);
-      theta = 0;
+    if ((sign(theta) != sign(direction)) || (abs(chordHeight) < .01)) {
+      // There is a parameter error in this line of gcode, either in the size of the angle calculated
+      //  or the chord height of the arc between the starting and ending points
+      // In either case, the gcode cut was essentially a straight line, so 
+      // Replace it with a G1 cut to the endpoint
+      String gcodeSubstitution = "G1 X";
+      gcodeSubstitution = gcodeSubstitution + String(X2 / sys.inchesToMMConversion, 3) + " Y" + String(Y2 / sys.inchesToMMConversion, 3) + " ";
+      Serial.println("Oops! This gcode line has caused a calculation error, it will be replaced by: " + gcodeSubstitution);
+      G1(gcodeSubstitution, 1);
+      return 1;
     }
 
     float arcLengthMM            =  circumference * (theta / (2*pi) );

--- a/cnc_ctrl_v1/Motion.cpp
+++ b/cnc_ctrl_v1/Motion.cpp
@@ -268,12 +268,6 @@ int   arc(const float& X1, const float& Y1, const float& X2, const float& Y2, co
       //  or the chord height of the arc between the starting and ending points
       // In either case, the gcode cut was essentially a straight line, so 
       // Replace it with a G1 cut to the endpoint
-      Serial.print("chordHeight ");
-      Serial.println(chordHeight,8);
-      Serial.print("theta ");
-      Serial.println(theta,8);
-      Serial.print("direction ");
-      Serial.println(direction,8);
       String gcodeSubstitution = "G1 X";
       gcodeSubstitution = gcodeSubstitution + String(X2 / sys.inchesToMMConversion, 3) + " Y" + String(Y2 / sys.inchesToMMConversion, 3) + " ";
       Serial.println("Oops! This gcode line has caused a calculation error, it will be replaced by: " + gcodeSubstitution);

--- a/cnc_ctrl_v1/Motion.cpp
+++ b/cnc_ctrl_v1/Motion.cpp
@@ -268,6 +268,12 @@ int   arc(const float& X1, const float& Y1, const float& X2, const float& Y2, co
       //  or the chord height of the arc between the starting and ending points
       // In either case, the gcode cut was essentially a straight line, so 
       // Replace it with a G1 cut to the endpoint
+      Serial.print("chordHeight ");
+      Serial.println(chordHeight,8);
+      Serial.print("theta ");
+      Serial.println(theta,8);
+      Serial.print("direction ");
+      Serial.println(direction,8);
       String gcodeSubstitution = "G1 X";
       gcodeSubstitution = gcodeSubstitution + String(X2 / sys.inchesToMMConversion, 3) + " Y" + String(Y2 / sys.inchesToMMConversion, 3) + " ";
       Serial.println("Oops! This gcode line has caused a calculation error, it will be replaced by: " + gcodeSubstitution);


### PR DESCRIPTION
The problem here is floating point precision, but it can be identified by looking at the height of the chord described by the G2/G3 command. Problematic commands have a chord that resolves to 0.01mm or less. This code trapps that situation and calls G1 instead using the endpoint. This turns an arc with less than 0.01mm of bow into a straight line.
 This is discussed in issue #426, and applies to the issue addressed in PR#428, replacing the code from that PR.