### PR TITLE
Test motors needs to be exempt from position error limit

### DIFF
--- a/cnc_ctrl_v1/GCode.cpp
+++ b/cnc_ctrl_v1/GCode.cpp
@@ -147,6 +147,8 @@ byte  executeBcodeLine(const String& gcodeLine){
     }
     
     if(gcodeLine.substring(0, 3) == "B04"){
+        //set flag to ignore position error limit during the tests
+        sys.state = (sys.state | STATE_POS_ERR_IGNORE);
         //Test each of the axis
         maslowDelay(500);
         if(sys.stop){return STATUS_OK;}
@@ -158,6 +160,9 @@ byte  executeBcodeLine(const String& gcodeLine){
         if(sys.stop){return STATUS_OK;}
         zAxis.test();
         Serial.println(F("Tests complete."));
+
+        //clear the flag, re-enable position error limit
+        sys.state = (sys.state & (!STATE_POS_ERR_IGNORE));
         return STATUS_OK;
     }
     

--- a/cnc_ctrl_v1/GCode.cpp
+++ b/cnc_ctrl_v1/GCode.cpp
@@ -161,6 +161,10 @@ byte  executeBcodeLine(const String& gcodeLine){
         zAxis.test();
         Serial.println(F("Tests complete."));
 
+        // update our position
+        leftAxis.set(leftAxis.read());
+        rightAxis.set(rightAxis.read());
+
         //clear the flag, re-enable position error limit
         sys.state = (sys.state & (!STATE_POS_ERR_IGNORE));
         return STATUS_OK;

--- a/cnc_ctrl_v1/Report.cpp
+++ b/cnc_ctrl_v1/Report.cpp
@@ -243,11 +243,12 @@ void  returnError(){
         Serial.print(',');
         Serial.print(incSerialBuffer.spaceAvailable());
         Serial.println(F("]"));
-        // float positionErrorLimit = 1.5;
         if (!sys.stop) {
-            if ((leftAxis.error() >= sysSettings.positionErrorLimit) || (rightAxis.error() >= sysSettings.positionErrorLimit)) {
+          if (!(sys.state & STATE_POS_ERR_IGNORE)) {
+            if ((abs(leftAxis.error()) >= sysSettings.positionErrorLimit) || abs((rightAxis.error()) >= sysSettings.positionErrorLimit)) {
                 reportAlarmMessage(ALARM_POSITION_LIMIT_ERROR);
             }
+          }
         }
 }
 

--- a/cnc_ctrl_v1/System.h
+++ b/cnc_ctrl_v1/System.h
@@ -40,6 +40,7 @@ Copyright 2014-2017 Bar Smith*/
 #define STATE_HOLD          bit(4) // Active feed hold
 #define STATE_SAFETY_DOOR   bit(5) // Safety door is ajar. Feed holds and de-energizes system.
 #define STATE_MOTION_CANCEL bit(6) // Motion cancel by feed hold and return to idle.
+#define STATE_POS_ERR_IGNORE bit(7) // Motion not checked for position error
 
 // Define old settings flag details
 #define NEED_ENCODER_STEPS bit(0)


### PR DESCRIPTION
Create a system flag to suspend checking for position error.
 Use it during B04 'Test Motors/Encoders'.
 Update our position after the test before re-enabling position error checking.