### PR TITLE
Add support for using the PWM pin

### DIFF
--- a/cnc_ctrl_v1/Motor.cpp
+++ b/cnc_ctrl_v1/Motor.cpp
@@ -90,29 +90,42 @@ void Motor::write(int speed){
         
         bool usePin1 = ((_pin1 != 4) && (_pin1 != 13) && (_pin1 != 11) && (_pin1 != 12)); // avoid PWM using timer0 or timer1
         bool usePin2 = ((_pin2 != 4) && (_pin2 != 13) && (_pin2 != 11) && (_pin2 != 12)); // avoid PWM using timer0 or timer1
-        if (forward) {
-            if (speed > 0) {
-              if (usePin2) {
+        bool usepwmPin = ((_pwmPin != 4) && (_pwmPin != 13) && (_pwmPin != 11) && (_pwmPin != 12)); // avoid PWM using timer0 or timer1
+        
+        
+        if (forward){
+            if (usepwmPin){
+                digitalWrite(_pin1 , HIGH );
+                digitalWrite(_pin2 ,  LOW  );
+                analogWrite(_pwmPin, speed);
+            }
+            else if (usePin2) {
                 digitalWrite(_pin1 , HIGH );
                 analogWrite(_pin2 , 255 - speed); // invert drive signals - don't alter speed
-              } else {
+                digitalWrite(_pwmPin, HIGH);
+            }
+            else{
                 analogWrite(_pin1 , speed);
                 digitalWrite(_pin2 , LOW );
-              }
-            } else {
-              digitalWrite(_pin1 , LOW );
-              digitalWrite(_pin2 , LOW );
+                digitalWrite(_pwmPin, HIGH);
             }
-        } else{
-            if (usePin1) {
-              analogWrite(_pin1 , 255 - speed); // invert drive signals - don't alter speed
-              digitalWrite(_pin2 , HIGH );
+        }
+        else{
+            if (usepwmPin){
+                digitalWrite(_pin2 , HIGH);
+                digitalWrite(_pin1 , LOW );
+                analogWrite(_pwmPin, speed);
+            }
+            else if (usePin1) {
+                analogWrite(_pin1 , 255 - speed); // invert drive signals - don't alter speed
+                digitalWrite(_pin2 , HIGH );
+                digitalWrite(_pwmPin, HIGH);
             } else {
                 analogWrite(_pin2 , speed);
                 digitalWrite(_pin1 , LOW );
+                digitalWrite(_pwmPin, HIGH);
             }
-        }  
-        digitalWrite(_pwmPin, HIGH);
+        }
     }
 }
 

--- a/cnc_ctrl_v1/Motor.cpp
+++ b/cnc_ctrl_v1/Motor.cpp
@@ -120,7 +120,8 @@ void Motor::write(int speed){
                 analogWrite(_pin1 , 255 - speed); // invert drive signals - don't alter speed
                 digitalWrite(_pin2 , HIGH );
                 digitalWrite(_pwmPin, HIGH);
-            } else {
+            }
+            else {
                 analogWrite(_pin2 , speed);
                 digitalWrite(_pin1 , LOW );
                 digitalWrite(_pwmPin, HIGH);


### PR DESCRIPTION
PCB version 1.2 moved around which pins are PWM pins and so the firmware needs to take this into account. There is an issue right now where when running PCB version 1.2 the left motor only gets one pulse every time the speed is set (at the frequency of of the PID loops) instead of at the PWM frequency which is higher resulting in the left motor not having full power.

The PR adds a usepwmpin option so that the PWM pin is used for PWM if it is not a pin used for one of the timers.

Tested on 1.1 and 1.2b