### PR TITLE
Make it possible to measure either chain

### DIFF
--- a/cnc_ctrl_v1/GCode.cpp
+++ b/cnc_ctrl_v1/GCode.cpp
@@ -232,7 +232,12 @@ byte  executeBcodeLine(const String& gcodeLine){
     if(gcodeLine.substring(0, 3) == "B10"){
         //measure the left axis chain length
         Serial.print(F("[Measure: "));
-        Serial.print(leftAxis.read());
+        if (gcodeLine.indexOf('L') != -1){
+            Serial.print(leftAxis.read());
+        }
+        else{
+            Serial.print(rightAxis.read());
+        }
         Serial.println(F("]"));
         return STATUS_OK;
     }

--- a/cnc_ctrl_v1/GCode.cpp
+++ b/cnc_ctrl_v1/GCode.cpp
@@ -259,15 +259,10 @@ byte  executeBcodeLine(const String& gcodeLine){
                 rightAxis.motorGearboxEncoder.motor.directWrite(speed);
             }
             
-            if (i % 10000 == 0){
-                Serial.println(F("pulling"));                              //Keep the connection from timing out
-            }
             i++;
             execSystemRealtime();
             if (sys.stop){return STATUS_OK;}
         }
-        leftAxis.set(leftAxis.read());
-        rightAxis.set(rightAxis.read());
         return STATUS_OK;
     }
     

--- a/cnc_ctrl_v1/GCode.cpp
+++ b/cnc_ctrl_v1/GCode.cpp
@@ -252,7 +252,13 @@ byte  executeBcodeLine(const String& gcodeLine){
         
         int i = 0;
         while (millis() - begin < ms){
-            leftAxis.motorGearboxEncoder.motor.directWrite(speed);
+            if (gcodeLine.indexOf('L') != -1){
+                leftAxis.motorGearboxEncoder.motor.directWrite(speed);
+            }
+            else{
+                rightAxis.motorGearboxEncoder.motor.directWrite(speed);
+            }
+            
             if (i % 10000 == 0){
                 Serial.println(F("pulling"));                              //Keep the connection from timing out
             }
@@ -261,6 +267,7 @@ byte  executeBcodeLine(const String& gcodeLine){
             if (sys.stop){return STATUS_OK;}
         }
         leftAxis.set(leftAxis.read());
+        rightAxis.set(rightAxis.read());
         return STATUS_OK;
     }
     

--- a/cnc_ctrl_v1/Motor.cpp
+++ b/cnc_ctrl_v1/Motor.cpp
@@ -78,11 +78,11 @@ void Motor::additiveWrite(int speed){
     write(_lastSpeed + speed);
 }
 
-void Motor::write(int speed){
+void Motor::write(int speed, bool force){
     /*
-    Sets motor speed from input. Speed = 0 is stopped, -255 is full reverse, 255 is full ahead.
+    Sets motor speed from input. Speed = 0 is stopped, -255 is full reverse, 255 is full ahead. If force is true 
     */
-    if (_attachedState == 1){
+    if (_attachedState == 1 or force){
         speed = constrain(speed, -255, 255);
         _lastSpeed = speed; //saves speed for use in additive write
         bool forward = (speed > 0);
@@ -134,21 +134,7 @@ void Motor::directWrite(int voltage){
     /*
     Write directly to the motor, ignoring if the axis is attached or any applied calibration.
     */
-    bool forward = (voltage >= 0);
-    if (forward) {
-        if (voltage > 0) {
-          digitalWrite(_pin1 , HIGH );
-          analogWrite(_pin2 , 255 - abs(voltage)); // invert drive signals - don't alter speed
-        } else {
-          digitalWrite(_pin1 , LOW );
-          digitalWrite(_pin2 , LOW );
-        }
-    }
-    else{
-        analogWrite(_pin1 , 255 - abs(voltage)); // invert drive signals - don't alter speed
-        digitalWrite(_pin2 , HIGH );
-    }
-    digitalWrite(_pwmPin, HIGH);
+    write(voltage, true);
 }
 
 int  Motor::attached(){

--- a/cnc_ctrl_v1/Motor.cpp
+++ b/cnc_ctrl_v1/Motor.cpp
@@ -80,7 +80,7 @@ void Motor::additiveWrite(int speed){
 
 void Motor::write(int speed, bool force){
     /*
-    Sets motor speed from input. Speed = 0 is stopped, -255 is full reverse, 255 is full ahead. If force is true 
+    Sets motor speed from input. Speed = 0 is stopped, -255 is full reverse, 255 is full ahead. If force is true the motor attached state will be ignored
     */
     if (_attachedState == 1 or force){
         speed = constrain(speed, -255, 255);

--- a/cnc_ctrl_v1/Motor.h
+++ b/cnc_ctrl_v1/Motor.h
@@ -35,7 +35,7 @@
             void attach();
             int  setupMotor(const int& pwmPin, const int& pin1, const int& pin2);
             void detach();
-            void write(int speed);
+            void write(int speed, bool force = false);
             int  lastSpeed();
             void additiveWrite(int speed);
             int  attached();

--- a/cnc_ctrl_v1/Settings.cpp
+++ b/cnc_ctrl_v1/Settings.cpp
@@ -382,6 +382,7 @@ byte settingsStoreGlobalSetting(const byte& parameter,const float& value){
               sysSettings.chainSagCorrection = value;
               break;
         case 38:
+              settingsSaveStepstoEEprom();
               sysSettings.chainOverSprocket = value;
               setupAxes();
               settingsLoadStepsFromEEprom();


### PR DESCRIPTION
This pull request adds the ability to measure the distance between the motors by using either chain.

It also cleans up the directWrite function to call the regular write function to ensure consistency across PCB versions. This has been tested but it's a change which effects multiple other places in the code so it's worth mentioning.

This pull request is part of an effort to create an automated system for measuring differences in the left vs right chains