### PR TITLE
Move bracket in alarm code

### DIFF
--- a/cnc_ctrl_v1/Report.cpp
+++ b/cnc_ctrl_v1/Report.cpp
@@ -245,7 +245,7 @@ void  returnError(){
         Serial.println(F("]"));
         if (!sys.stop) {
           if (!(sys.state & STATE_POS_ERR_IGNORE)) {
-            if ((abs(leftAxis.error()) >= sysSettings.positionErrorLimit) || abs((rightAxis.error()) >= sysSettings.positionErrorLimit)) {
+            if ((abs(leftAxis.error()) >= sysSettings.positionErrorLimit) || (abs(rightAxis.error()) >= sysSettings.positionErrorLimit)) {
                 reportAlarmMessage(ALARM_POSITION_LIMIT_ERROR);
             }
           }


### PR DESCRIPTION
When I was testing the reworded popup I noticed that the alarm triggered in every direction except when the right motor was moving to the left and I think this bracket needs to be moved over one place for the abs() to apply to the error and not the bool compare value 🙄 