### PR TITLE
Remove "TLE5206-release firmware" from sketch startup.

### DIFF
--- a/cnc_ctrl_v1/cnc_ctrl_v1.ino
+++ b/cnc_ctrl_v1/cnc_ctrl_v1.ino
@@ -59,7 +59,6 @@ void setup(){
     Serial.print(getPCBVersion());
     if (TLE5206 == true) { Serial.print(F(" TLE5206 ")); }
     Serial.println(F(" Detected"));
-		Serial.println(F("TLE5206-release firmware"));
     sys.inchesToMMConversion = 1;
     settingsLoadFromEEprom();
     setupAxes();


### PR DESCRIPTION
This was useful before merging to the master, no longer needed.