### PR TITLE
Convert arc with radius greater thanb 2500mm to a straight line

### DIFF
--- a/cnc_ctrl_v1/Motion.cpp
+++ b/cnc_ctrl_v1/Motion.cpp
@@ -263,7 +263,7 @@ int   arc(const float& X1, const float& Y1, const float& X2, const float& Y2, co
             theta -= 2*pi;
         }
     }
-    if ((sign(theta) != sign(direction)) || ((abs(chordHeight) < .01) && (abs(theta) < 0.5))) {
+    if ((sign(theta) != sign(direction)) || ((abs(chordHeight) < .01) && (abs(theta) < 0.5)) || (radius > 2500)) {
       // There is a parameter error in this line of gcode, either in the size of the angle calculated
       //  or the chord height of the arc between the starting and ending points
       // In either case, the gcode cut was essentially a straight line, so 


### PR DESCRIPTION
PR#420 added code to convert problematic G2/G3 arcs to G2 lines. This adds arcs with radius greater than 2500mm to the list of items converted. 

@Bar suggested 'a few thousand inches' [in Issue #426 ](https://github.com/MaslowCNC/Firmware/issues/426#issuecomment-379930897), this is less than that.

This addresses the issue discussed in [this forum topic](https://forums.maslowcnc.com/t/maslow-with-a-mind-of-its-own/4088).