### PR TITLE
Turn off the warning for the G40 command

### DIFF
--- a/cnc_ctrl_v1/GCode.cpp
+++ b/cnc_ctrl_v1/GCode.cpp
@@ -373,6 +373,8 @@ void  executeGcodeLine(const String& gcodeLine){
         case 21:
             setInchesToMillimetersConversion(MILLIMETERS);
             break;
+        case 40:
+            break; //the G40 command turns off cutter compensation which is already off so it is safe to ignore
         case 38:
             G38(gcodeLine);
             break;


### PR DESCRIPTION
G40 turns off cutter compensation which is already off so no need to do anything or spawn a warning.

See thread: https://forums.maslowcnc.com/t/command-g40-unsupported-and-ignored/4193/20