### PR TITLE
Add support for M106 and M107

### DIFF
--- a/cnc_ctrl_v1/GCode.cpp
+++ b/cnc_ctrl_v1/GCode.cpp
@@ -427,6 +427,14 @@ void  executeMcodeLine(const String& gcodeLine){
                 pause();
             }
             break;
+        case 106:
+            //Turn laser on
+            laserOn();
+            break;
+        case 107:
+            //Turn laser off
+            laserOff();
+            break;
         default:
             Serial.print(F("Command M"));
             Serial.print(mNumber);

--- a/cnc_ctrl_v1/Spindle.cpp
+++ b/cnc_ctrl_v1/Spindle.cpp
@@ -17,7 +17,7 @@
 #include "Maslow.h"
 #include "Settings.h"
 
-// the variable SpindlePowerControlPin and LaserPowerPin are assigned in configAuxLow() in System.cpp 
+// the variables SpindlePowerControlPin and LaserPowerPin are assigned in configAuxLow() in System.cpp 
 
 // Globals for Spindle control, both poorly named
 Servo myservo;  // create servo object to control a servo
@@ -105,8 +105,12 @@ void  setSpindlePower(bool powerState) {
 
 void laserOn() {
     Serial.println("Laser on");
+    pinMode(LaserPowerPin, OUTPUT);
+    digitalWrite(LaserPowerPin, HIGH);
 }
 
 void laserOff(){
     Serial.println("Laser off");
+    pinMode(LaserPowerPin, OUTPUT);
+    digitalWrite(LaserPowerPin, LOW);
 }

--- a/cnc_ctrl_v1/Spindle.cpp
+++ b/cnc_ctrl_v1/Spindle.cpp
@@ -17,7 +17,7 @@
 #include "Maslow.h"
 #include "Settings.h"
 
-// the variable SpindlePowerControlPin is assigned in configAuxLow() in System.cpp 
+// the variable SpindlePowerControlPin and LaserPowerPin are assigned in configAuxLow() in System.cpp 
 
 // Globals for Spindle control, both poorly named
 Servo myservo;  // create servo object to control a servo
@@ -101,4 +101,12 @@ void  setSpindlePower(bool powerState) {
     if (spindleAutomateType != NONE) {
         maslowDelay(delayAfterChange);
     }
+}
+
+void laserOn() {
+    Serial.println("Laser on");
+}
+
+void laserOff(){
+    Serial.println("Laser off");
 }

--- a/cnc_ctrl_v1/Spindle.h
+++ b/cnc_ctrl_v1/Spindle.h
@@ -18,5 +18,7 @@
 #define spindle_h
 
 void  setSpindlePower(bool powerState);
+void  laserOn();
+void  laserOff();
 
 #endif

--- a/cnc_ctrl_v1/System.cpp
+++ b/cnc_ctrl_v1/System.cpp
@@ -24,7 +24,7 @@ bool TLE5206;
 // extern values using AUX pins defined in  configAuxLow() and configAuxHigh()
 int SpindlePowerControlPin;  // output for controlling spindle power
 int ProbePin;                // use this input for zeroing zAxis with G38.2 gcode
-int LaserPowerPin;           //Use this output to turn on and off a laser diode
+int LaserPowerPin;           // Use this output to turn on and off a laser diode
 
 
 void  calibrateChainLengths(String gcodeLine){
@@ -255,6 +255,8 @@ void configAuxLow(int aux1, int aux2, int aux3, int aux4, int aux5, int aux6) {
   SpindlePowerControlPin = aux1;   // output for controlling spindle power
   ProbePin = aux4;                 // use this input for zeroing zAxis with G38.2 gcode
   LaserPowerPin = aux2;            // output for controlling a laser diode
+  pinMode(LaserPowerPin, OUTPUT);
+  digitalWrite(LaserPowerPin, LOW);
 }
 
 void configAuxHigh(int aux7, int aux8, int aux9) {

--- a/cnc_ctrl_v1/System.cpp
+++ b/cnc_ctrl_v1/System.cpp
@@ -24,6 +24,7 @@ bool TLE5206;
 // extern values using AUX pins defined in  configAuxLow() and configAuxHigh()
 int SpindlePowerControlPin;  // output for controlling spindle power
 int ProbePin;                // use this input for zeroing zAxis with G38.2 gcode
+int LaserPowerPin;           //Use this output to turn on and off a laser diode
 
 
 void  calibrateChainLengths(String gcodeLine){
@@ -253,6 +254,7 @@ void   setupAxes(){
 void configAuxLow(int aux1, int aux2, int aux3, int aux4, int aux5, int aux6) {
   SpindlePowerControlPin = aux1;   // output for controlling spindle power
   ProbePin = aux4;                 // use this input for zeroing zAxis with G38.2 gcode
+  LaserPowerPin = aux2;            // output for controlling a laser diode
 }
 
 void configAuxHigh(int aux7, int aux8, int aux9) {

--- a/cnc_ctrl_v1/System.h
+++ b/cnc_ctrl_v1/System.h
@@ -76,6 +76,7 @@ extern RingBuffer incSerialBuffer;
 extern Kinematics kinematics;
 extern byte systemRtExecAlarm;
 extern int SpindlePowerControlPin;
+extern int LaserPowerPin;
 extern int ProbePin;
 
 void  calibrateChainLengths(String);


### PR DESCRIPTION
This PR adds support for using the M106 and M107 to turn on and off a laser diode controlled by port AUX2.

This has not been tested with a laser since I don't have one.

Original request can be found in the forums here:

https://forums.maslowcnc.com/t/laser-engrave-project-with-maslow-need-help-please/4363