### PR TITLE
B11 should not trigger position error alarm

### DIFF
--- a/cnc_ctrl_v1/GCode.cpp
+++ b/cnc_ctrl_v1/GCode.cpp
@@ -251,6 +251,7 @@ byte  executeBcodeLine(const String& gcodeLine){
         double begin = millis();
 
         int i = 0;
+        sys.state = (sys.state | STATE_POS_ERR_IGNORE);
         while (millis() - begin < ms){
             if (gcodeLine.indexOf('L') != -1){
                 leftAxis.motorGearboxEncoder.motor.directWrite(speed);
@@ -263,6 +264,7 @@ byte  executeBcodeLine(const String& gcodeLine){
             execSystemRealtime();
             if (sys.stop){return STATUS_OK;}
         }
+        sys.state = (sys.state | (!STATE_POS_ERR_IGNORE));
         return STATUS_OK;
     }
 


### PR DESCRIPTION
The B11 gcode moves a motor at speed S for T seconds. It should not trigger the position error alarm as it is a testing gcode.

Usage example (moves the left motor at speed 200 for 2 seconds:
B11 L1 S200 T2

(S)peed accepts a float but treats that as an integer 0..255
(T)ime is a float