### PR TITLE
If zEncoderSteps is negative, use that same sign in G38.2 gcode

### DIFF
--- a/cnc_ctrl_v1/GCode.cpp
+++ b/cnc_ctrl_v1/GCode.cpp
@@ -781,8 +781,9 @@ void  G38(const String& readString) {
 
 
       float currentZPos = zAxis.read();
+      int   zDirection = sysSettings.zEncoderSteps<0 ? -1 : 1;
 
-      zgoto      = sys.inchesToMMConversion * extractGcodeValue(readString, 'Z', currentZPos / sys.inchesToMMConversion);
+      zgoto = zDirection * sys.inchesToMMConversion * extractGcodeValue(readString, 'Z', currentZPos / sys.inchesToMMConversion);
       sys.feedrate   = sys.inchesToMMConversion * extractGcodeValue(readString, 'F', sys.feedrate / sys.inchesToMMConversion);
       sys.feedrate = constrain(sys.feedrate, 1, sysSettings.maxZRPM * abs(zAxis.getPitch()));
 


### PR DESCRIPTION
Make G38.2 aware of inverted z axis motion.
 Some non-stock z motors reverse the motor and encoder leads. Some users accomodate this by making the GC setting "Z-Axis Encoder Steps per Revolution" negative. This commit uses the sign of that 'sysSettings.zEncoderSteps' firmware setting to adjust the direction of travel inGcode.cpp:G38().