### PR TITLE
add missing setting to defaults in Settings:settingsReset()

### DIFF
--- a/cnc_ctrl_v1/Settings.cpp
+++ b/cnc_ctrl_v1/Settings.cpp
@@ -73,6 +73,7 @@ void settingsReset() {
     sysSettings.kinematicsType = 1;      // byte kinematicsType;
     sysSettings.rotationDiskRadius = 250.0;  // float rotationDiskRadius;
     sysSettings.axisDetachTime = 2000;   // int axisDetachTime;
+    sysSettings.chainLength = 3360;   // int maximum length of chain;
     sysSettings.originalChainLength = 1650;   // int originalChainLength;
     sysSettings.encoderSteps = 8113.7; // float encoderSteps;
     sysSettings.distPerRot = 63.5;   // float distPerRot;


### PR DESCRIPTION
settingsReset() does not include a default value for chainLength. Without a value for chainLength,  kinematics fails with:
```
"Message: Unable to find valid machine position for chain lengths "
```
GC responds by sending it's own setting value ($10), but the kinematics error requires the user to recalibrate the chains.