### PR TITLE
Beam tilt correction

### DIFF
--- a/cnc_ctrl_v1/Kinematics.cpp
+++ b/cnc_ctrl_v1/Kinematics.cpp
@@ -53,7 +53,7 @@ void Kinematics::recomputeGeometry(){
     Theta = atan(2*sysSettings.sledHeight/sysSettings.sledWidth);
     Psi1 = Theta - Phi;
     Psi2 = Theta + Phi;
-
+  
     halfWidth = sysSettings.machineWidth / 2.0;
     halfHeight = sysSettings.machineHeight / 2.0;
 
@@ -65,19 +65,19 @@ void Kinematics::recomputeGeometry(){
 
 void  Kinematics::inverse(float xTarget,float yTarget, float* aChainLength, float* bChainLength){
     /*
-
-    This function works as a switch to call either the quadrilateralInverse kinematic function
+    
+    This function works as a switch to call either the quadrilateralInverse kinematic function 
     or the triangularInverse kinematic function
-
+    
     */
-
+    
     if(sysSettings.kinematicsType == 1){
         quadrilateralInverse(xTarget, yTarget, aChainLength, bChainLength);
     }
     else{
         triangularInverse(xTarget, yTarget, aChainLength, bChainLength);
     }
-
+    
 }
 
 void  Kinematics::quadrilateralInverse(float xTarget,float yTarget, float* aChainLength, float* bChainLength){
@@ -193,13 +193,13 @@ void  Kinematics::quadrilateralInverse(float xTarget,float yTarget, float* aChai
 
 void  Kinematics::triangularInverse(float xTarget,float yTarget, float* aChainLength, float* bChainLength){
     /*
-
+    
     The inverse kinematics (relating an xy coordinate pair to the required chain lengths to hit that point)
-    function for a triangular set up where the chains meet at a point, or are arranged so that they simulate
+    function for a triangular set up where the chains meet at a point, or are arranged so that they simulate 
     meeting at a point.
-
+    
     */
-
+    
     //Confirm that the coordinates are on the wood
     _verifyValidTarget(&xTarget, &yTarget);
 
@@ -244,15 +244,15 @@ void  Kinematics::triangularInverse(float xTarget,float yTarget, float* aChainLe
     //Subtract of the virtual length which is added to the chain by the rotation mechanism
     Chain1 = Chain1 - sysSettings.rotationDiskRadius;
     Chain2 = Chain2 - sysSettings.rotationDiskRadius;
-
+    
     *aChainLength = Chain1;
     *bChainLength = Chain2;
 }
 
 void  Kinematics::forward(const float& chainALength, const float& chainBLength, float* xPos, float* yPos, float xGuess, float yGuess){
-
+  
     Serial.println(F("[Forward Calculating Position]"));
-
+    
 
     float guessLengthA;
     float guessLengthB;
@@ -272,10 +272,10 @@ void  Kinematics::forward(const float& chainALength, const float& chainBLength, 
         //adjust the guess based on the result
         xGuess = xGuess + .1*aChainError - .1*bChainError;
         yGuess = yGuess - .1*aChainError - .1*bChainError;
-
+        
         guessCount++;
 
-        #if defined (KINEMATICSDBG) && KINEMATICSDBG > 0
+        #if defined (KINEMATICSDBG) && KINEMATICSDBG > 0 
           Serial.print(F("[PEk:"));
           Serial.print(aChainError);
           Serial.print(',');

--- a/cnc_ctrl_v1/Kinematics.cpp
+++ b/cnc_ctrl_v1/Kinematics.cpp
@@ -56,8 +56,6 @@ void Kinematics::recomputeGeometry(){
 
     halfWidth = sysSettings.machineWidth / 2.0;
     halfHeight = sysSettings.machineHeight / 2.0;
-    _xCordOfMotor = sysSettings.distBetweenMotors/2;
-    _yCordOfMotor = halfHeight + sysSettings.motorOffsetY;
 
     leftMotorX = cos(sysSettings.topBeamTilt*0.0174532925199433)*sysSettings.distBetweenMotors/-2.0;
     leftMotorY = sin(sysSettings.topBeamTilt*0.0174532925199433)*sysSettings.distBetweenMotors/-2.0 + (sysSettings.motorOffsetY+sysSettings.machineHeight/2.0);

--- a/cnc_ctrl_v1/Kinematics.cpp
+++ b/cnc_ctrl_v1/Kinematics.cpp
@@ -57,10 +57,10 @@ void Kinematics::recomputeGeometry(){
     halfWidth = sysSettings.machineWidth / 2.0;
     halfHeight = sysSettings.machineHeight / 2.0;
 
-    leftMotorX = cos(sysSettings.topBeamTilt*0.0174532925199433)*sysSettings.distBetweenMotors/-2.0;
-    leftMotorY = sin(sysSettings.topBeamTilt*0.0174532925199433)*sysSettings.distBetweenMotors/-2.0 + (sysSettings.motorOffsetY+sysSettings.machineHeight/2.0);
-    rightMotorX = cos(sysSettings.topBeamTilt*0.0174532925199433)*sysSettings.distBetweenMotors+leftMotorX;
-    rightMotorY = sin(sysSettings.topBeamTilt*0.0174532925199433)*sysSettings.distBetweenMotors/2.0 + (sysSettings.motorOffsetY+sysSettings.machineHeight/2.0);
+    leftMotorX = cos(sysSettings.topBeamTilt*DEG_TO_RAD)*sysSettings.distBetweenMotors/-2.0;
+    leftMotorY = sin(sysSettings.topBeamTilt*DEG_TO_RAD)*sysSettings.distBetweenMotors/-2.0 + (sysSettings.motorOffsetY+sysSettings.machineHeight/2.0);
+    rightMotorX = cos(sysSettings.topBeamTilt*DEG_TO_RAD)*sysSettings.distBetweenMotors+leftMotorX;
+    rightMotorY = sin(sysSettings.topBeamTilt*DEG_TO_RAD)*sysSettings.distBetweenMotors/2.0 + (sysSettings.motorOffsetY+sysSettings.machineHeight/2.0);
 }
 
 void  Kinematics::inverse(float xTarget,float yTarget, float* aChainLength, float* bChainLength){

--- a/cnc_ctrl_v1/Kinematics.h
+++ b/cnc_ctrl_v1/Kinematics.h
@@ -12,9 +12,9 @@
 
     You should have received a copy of the GNU General Public License
     along with the Maslow Control Software.  If not, see <http://www.gnu.org/licenses/>.
-
+    
     Copyright 2014-2017 Bar Smith*/
-
+    
     #ifndef Kinematics_h
     #define Kinematics_h
 
@@ -63,7 +63,7 @@
 
             //Criterion Computation Variables
             float Phi = -0.2;
-            float TanGamma;
+            float TanGamma; 
             float TanLambda;
             float Y1Plus ;
             float Y2Plus;
@@ -97,7 +97,7 @@
             float Motor2Distance; //right motor axis distance to sled
 
             // output = chain lengths measured from 12 o'clock
-            float Chain1; //left chain length
+            float Chain1; //left chain length 
             float Chain2; //right chain length
     };
 

--- a/cnc_ctrl_v1/Kinematics.h
+++ b/cnc_ctrl_v1/Kinematics.h
@@ -12,9 +12,9 @@
 
     You should have received a copy of the GNU General Public License
     along with the Maslow Control Software.  If not, see <http://www.gnu.org/licenses/>.
-    
+
     Copyright 2014-2017 Bar Smith*/
-    
+
     #ifndef Kinematics_h
     #define Kinematics_h
 
@@ -40,8 +40,11 @@
             float R             = 10.1;                                //sprocket radius
             float RleftChainTolerance = 10.1;    // Left sprocket radius including chain tolerance
             float RrightChainTolerance = 10.1;    // Right sprocket radius including chain tolerance
-            
 
+            float leftMotorX = -1800.0;
+            float leftMotorY = -1200.0;
+            float rightMotorX = 1800.0;
+            float rightMotorY = -1200.0;
 
             float halfWidth;                      //Half the machine width
             float halfHeight;                    //Half the machine height
@@ -62,7 +65,7 @@
 
             //Criterion Computation Variables
             float Phi = -0.2;
-            float TanGamma; 
+            float TanGamma;
             float TanLambda;
             float Y1Plus ;
             float Y2Plus;
@@ -96,7 +99,7 @@
             float Motor2Distance; //right motor axis distance to sled
 
             // output = chain lengths measured from 12 o'clock
-            float Chain1; //left chain length 
+            float Chain1; //left chain length
             float Chain2; //right chain length
     };
 

--- a/cnc_ctrl_v1/Kinematics.h
+++ b/cnc_ctrl_v1/Kinematics.h
@@ -57,8 +57,6 @@
             //target router bit coordinates.
             float x = 0;
             float y = 0;
-            float _xCordOfMotor;
-            float _yCordOfMotor;
 
             //utility variables
             boolean Mirror;

--- a/cnc_ctrl_v1/Report.cpp
+++ b/cnc_ctrl_v1/Report.cpp
@@ -21,12 +21,12 @@ Copyright 2014-2017 Bar Smith*/
 
 void  reportStatusMessage(byte status_code){
     /*
-
+    
     Sends confirmation protocol response for commands. For every incoming line,
     this method responds with an 'ok' for a successful command or an 'error:'
     to indicate some error event with the line or some critical system error during
     operation.
-
+    
     Taken from Grbl http://github.com/grbl/grbl
     */
     if (status_code == 0) { // STATUS_OK
@@ -183,7 +183,7 @@ void reportMaslowSettings() {
     Serial.print(F("$41=")); Serial.println(sysSettings.distPerRotRightChainTolerance, 8);
     Serial.print(F("$42=")); Serial.println(sysSettings.positionErrorLimit, 8);
     Serial.print(F("$43=")); Serial.println(sysSettings.topBeamTilt, 8);
-
+    
   #else
     Serial.print(F("$0=")); Serial.print(sysSettings.machineWidth);
     Serial.print(F(" (machine width, mm)\r\n$1=")); Serial.print(sysSettings.machineHeight, 8);
@@ -240,7 +240,7 @@ void reportMaslowSettings() {
 
 void  returnError(){
     /*
-    Prints the machine's positional error and the amount of space available in the
+    Prints the machine's positional error and the amount of space available in the 
     gcode buffer
     */
         Serial.print(F("[PE:"));
@@ -262,15 +262,15 @@ void  returnError(){
 void  returnPoz(){
     /*
     Causes the machine's position (x,y) to be sent over the serial connection updated on the UI
-    in Ground Control. Also causes the error report to be sent. Only executes
+    in Ground Control. Also causes the error report to be sent. Only executes 
     if hasn't been called in at least POSITIONTIMEOUT ms.
     */
-
+    
     static unsigned long lastRan = millis();
-
+    
     if (millis() - lastRan > POSITIONTIMEOUT){
-
-
+        
+        
         Serial.print(F("<"));
         if (sys.stop){
             Serial.print(F("Stop,MPos:"));
@@ -287,13 +287,13 @@ void  returnPoz(){
         Serial.print(F(","));
         Serial.print(zAxis.read()/sys.inchesToMMConversion);
         Serial.println(F(",WPos:0.000,0.000,0.000>"));
-
-
+        
+        
         returnError();
-
+        
         lastRan = millis();
     }
-
+    
 }
 
 void  reportMaslowHelp(){

--- a/cnc_ctrl_v1/Report.cpp
+++ b/cnc_ctrl_v1/Report.cpp
@@ -21,12 +21,12 @@ Copyright 2014-2017 Bar Smith*/
 
 void  reportStatusMessage(byte status_code){
     /*
-    
+
     Sends confirmation protocol response for commands. For every incoming line,
     this method responds with an 'ok' for a successful command or an 'error:'
     to indicate some error event with the line or some critical system error during
     operation.
-    
+
     Taken from Grbl http://github.com/grbl/grbl
     */
     if (status_code == 0) { // STATUS_OK
@@ -182,7 +182,8 @@ void reportMaslowSettings() {
     Serial.print(F("$40=")); Serial.println(sysSettings.distPerRotLeftChainTolerance, 8);
     Serial.print(F("$41=")); Serial.println(sysSettings.distPerRotRightChainTolerance, 8);
     Serial.print(F("$42=")); Serial.println(sysSettings.positionErrorLimit, 8);
-    
+    Serial.print(F("$43=")); Serial.println(sysSettings.topBeamTilt, 8);
+
   #else
     Serial.print(F("$0=")); Serial.print(sysSettings.machineWidth);
     Serial.print(F(" (machine width, mm)\r\n$1=")); Serial.print(sysSettings.machineHeight, 8);
@@ -226,14 +227,20 @@ void reportMaslowSettings() {
     Serial.print(F(" (PWM frequency value 1=39,000Hz, 2=4,100Hz, 3=490Hz)\r\n$40=")); Serial.print(sysSettings.distPerRotLeftChainTolerance, 8);
     Serial.print(F(" (distance / rotation, including chain tolerance, left chain, mm)\r\n$41=")); Serial.print(sysSettings.distPerRotRightChainTolerance, 8);
     Serial.print(F(" (distance / rotation, including chain tolerance, right chain, mm)\r\n$42=")); Serial.print(sysSettings.positionErrorLimit, 8);
-    Serial.print(F(" (position error alarm limit, mm)"));
+    Serial.print(F(" (position error alarm limit, mm\r\n$43=)")); Serial.print(sysSettings.topBeamTilt, 8);
+    Serial.print(F(" (top beam tilt, degrees)\r\n"));
+    Serial.print(F(" (right chain tolerance, degrees)\r\n")); Serial.print(kinematics.leftMotorX,8);
+    Serial.print(F(" (left Motor X, mm)\r\n")); Serial.print(kinematics.leftMotorY,8);
+    Serial.print(F(" (left Motor Y, mm)\r\n")); Serial.print(kinematics.rightMotorX,8);
+    Serial.print(F(" (right Motor X, mm)\r\n")); Serial.print(kinematics.rightMotorY,8);
+    Serial.print(F(" (right Motor Y, mm)\r\n"));
     Serial.println();
   #endif
 }
 
 void  returnError(){
     /*
-    Prints the machine's positional error and the amount of space available in the 
+    Prints the machine's positional error and the amount of space available in the
     gcode buffer
     */
         Serial.print(F("[PE:"));
@@ -255,15 +262,15 @@ void  returnError(){
 void  returnPoz(){
     /*
     Causes the machine's position (x,y) to be sent over the serial connection updated on the UI
-    in Ground Control. Also causes the error report to be sent. Only executes 
+    in Ground Control. Also causes the error report to be sent. Only executes
     if hasn't been called in at least POSITIONTIMEOUT ms.
     */
-    
+
     static unsigned long lastRan = millis();
-    
+
     if (millis() - lastRan > POSITIONTIMEOUT){
-        
-        
+
+
         Serial.print(F("<"));
         if (sys.stop){
             Serial.print(F("Stop,MPos:"));
@@ -280,13 +287,13 @@ void  returnPoz(){
         Serial.print(F(","));
         Serial.print(zAxis.read()/sys.inchesToMMConversion);
         Serial.println(F(",WPos:0.000,0.000,0.000>"));
-        
-        
+
+
         returnError();
-        
+
         lastRan = millis();
     }
-    
+
 }
 
 void  reportMaslowHelp(){

--- a/cnc_ctrl_v1/Settings.cpp
+++ b/cnc_ctrl_v1/Settings.cpp
@@ -298,7 +298,7 @@ byte settingsStoreGlobalSetting(const byte& parameter,const float& value){
         case 16:
               sysSettings.zAxisAttached = value;
               break;
-        case 17:
+        case 17: 
               sysSettings.spindleAutomateType = static_cast<SpindleAutomationType>(value);
               break;
         case 18:

--- a/cnc_ctrl_v1/Settings.cpp
+++ b/cnc_ctrl_v1/Settings.cpp
@@ -105,6 +105,7 @@ void settingsReset() {
     sysSettings.distPerRotLeftChainTolerance = 63.5;    // float distPerRotLeftChainTolerance;
     sysSettings.distPerRotRightChainTolerance = 63.5;    // float distPerRotRightChainTolerance;
     sysSettings.positionErrorLimit = 2.0;  // float positionErrorLimit;
+    sysSettings.topBeamTilt = 0.0;
     sysSettings.eepromValidData = EEPROMVALIDDATA; // byte eepromValidData;
 }
 
@@ -234,9 +235,11 @@ byte settingsStoreGlobalSetting(const byte& parameter,const float& value){
                       break;
                 case 2:
                       sysSettings.distBetweenMotors = value;
+                      kinematics.recomputeGeometry();
                       break;
                 case 3:
                       sysSettings.motorOffsetY = value;
+                      kinematics.recomputeGeometry();
                       break;
                 case 4:
                       sysSettings.sledWidth = value;
@@ -294,7 +297,7 @@ byte settingsStoreGlobalSetting(const byte& parameter,const float& value){
         case 16:
               sysSettings.zAxisAttached = value;
               break;
-        case 17: 
+        case 17:
               sysSettings.spindleAutomateType = static_cast<SpindleAutomationType>(value);
               break;
         case 18:
@@ -409,6 +412,10 @@ byte settingsStoreGlobalSetting(const byte& parameter,const float& value){
               break;
         case 42:
               sysSettings.positionErrorLimit = value;
+              break;
+        case 43:
+              sysSettings.topBeamTilt = value;
+              kinematics.recomputeGeometry();
               break;
         default:
               return(STATUS_INVALID_STATEMENT);

--- a/cnc_ctrl_v1/Settings.cpp
+++ b/cnc_ctrl_v1/Settings.cpp
@@ -232,6 +232,7 @@ byte settingsStoreGlobalSetting(const byte& parameter,const float& value){
                       break;
                 case 1:
                       sysSettings.machineHeight = value;
+                      kinematics.recomputeGeometry();
                       break;
                 case 2:
                       sysSettings.distBetweenMotors = value;

--- a/cnc_ctrl_v1/Settings.h
+++ b/cnc_ctrl_v1/Settings.h
@@ -23,8 +23,8 @@ Copyright 2014-2017 Bar Smith*/
 #define SETTINGSVERSION 5      // The current version of settings, if this doesn't
                                // match what is in EEPROM then settings on
                                // machine are reset to defaults
-#define EEPROMVALIDDATA 56     // This is just a random byte value that is used
-                               // to determine if the data in the EEPROM was
+#define EEPROMVALIDDATA 56     // This is just a random byte value that is used 
+                               // to determine if the data in the EEPROM was 
                                // saved by maslow, or something else.
 
 // Reset Types

--- a/cnc_ctrl_v1/Settings.h
+++ b/cnc_ctrl_v1/Settings.h
@@ -20,11 +20,11 @@ Copyright 2014-2017 Bar Smith*/
 #ifndef settings_h
 #define settings_h
 
-#define SETTINGSVERSION 4      // The current version of settings, if this doesn't
+#define SETTINGSVERSION 5      // The current version of settings, if this doesn't
                                // match what is in EEPROM then settings on
                                // machine are reset to defaults
-#define EEPROMVALIDDATA 56     // This is just a random byte value that is used 
-                               // to determine if the data in the EEPROM was 
+#define EEPROMVALIDDATA 56     // This is just a random byte value that is used
+                               // to determine if the data in the EEPROM was
                                // saved by maslow, or something else.
 
 // Reset Types
@@ -81,6 +81,7 @@ typedef struct {  // I think this is about ~128 bytes in size if I counted corre
   float distPerRotLeftChainTolerance;
   float distPerRotRightChainTolerance;
   float positionErrorLimit;
+  float topBeamTilt;
   byte eepromValidData;  // This should always be last, that way if an error
                          // happens in writing, it will not be written and we
 } settings_t;            // will know to reset the settings


### PR DESCRIPTION
I'm starting to cherry-pick features and fixes from @madgrizzle's fork so that we can get them merged back upstream.

This change adds beam tilt correction -- From reading the code, it adjusts the x,y coordinates of the motors to account for the top beam being out-of-level.

Related GroundControl change is in https://github.com/MaslowCNC/GroundControl/pull/779