### PR TITLE
Simplified Chain Tolerance Correction

### DIFF
--- a/cnc_ctrl_v1/Kinematics.cpp
+++ b/cnc_ctrl_v1/Kinematics.cpp
@@ -59,6 +59,8 @@ void Kinematics::recomputeGeometry(){
     _xCordOfMotor = sysSettings.distBetweenMotors/2;
     _yCordOfMotor = halfHeight + sysSettings.motorOffsetY;
 
+    leftChainTolerance = sysSettings.distPerRot/sysSettings.distPerRotLeftChainTolerance;
+    rightChainTolerance = sysSettings.distPerRot/sysSettings.distPerRotRightChainTolerance;
 }
 
 void  Kinematics::inverse(float xTarget,float yTarget, float* aChainLength, float* bChainLength){
@@ -213,31 +215,31 @@ void  Kinematics::triangularInverse(float xTarget,float yTarget, float* aChainLe
 
     //Calculate the chain angles from horizontal, based on if the chain connects to the sled from the top or bottom of the sprocket
     if(sysSettings.chainOverSprocket == 1){
-        Chain1Angle = asin((_yCordOfMotor - yTarget)/Motor1Distance) + asin(RleftChainTolerance/Motor1Distance);
-        Chain2Angle = asin((_yCordOfMotor - yTarget)/Motor2Distance) + asin(RrightChainTolerance/Motor2Distance);
+        Chain1Angle = asin((_yCordOfMotor - yTarget)/Motor1Distance) + asin(R/Motor1Distance);
+        Chain2Angle = asin((_yCordOfMotor - yTarget)/Motor2Distance) + asin(R/Motor2Distance);
 
-        Chain1AroundSprocket = RleftChainTolerance * Chain1Angle;
-        Chain2AroundSprocket = RrightChainTolerance * Chain2Angle;
+        Chain1AroundSprocket = R * Chain1Angle;
+        Chain2AroundSprocket = R * Chain2Angle;
     }
     else{
-        Chain1Angle = asin((_yCordOfMotor - yTarget)/Motor1Distance) - asin(RleftChainTolerance/Motor1Distance);
-        Chain2Angle = asin((_yCordOfMotor - yTarget)/Motor2Distance) - asin(RrightChainTolerance/Motor2Distance);
+        Chain1Angle = asin((_yCordOfMotor - yTarget)/Motor1Distance) - asin(R/Motor1Distance);
+        Chain2Angle = asin((_yCordOfMotor - yTarget)/Motor2Distance) - asin(R/Motor2Distance);
 
-        Chain1AroundSprocket = RleftChainTolerance * (3.14159 - Chain1Angle);
-        Chain2AroundSprocket = RrightChainTolerance * (3.14159 - Chain2Angle);
+        Chain1AroundSprocket = R * (3.14159 - Chain1Angle);
+        Chain2AroundSprocket = R * (3.14159 - Chain2Angle);
     }
 
     //Calculate the straight chain length from the sprocket to the bit
-    float Chain1Straight = sqrt(pow(Motor1Distance,2)-pow(RleftChainTolerance,2));
-    float Chain2Straight = sqrt(pow(Motor2Distance,2)-pow(RrightChainTolerance,2));
+    float Chain1Straight = sqrt(pow(Motor1Distance,2)-pow(R,2));
+    float Chain2Straight = sqrt(pow(Motor2Distance,2)-pow(R,2));
 
     //Correct the straight chain lengths to account for chain sag
     Chain1Straight *= (1 + ((sysSettings.chainSagCorrection / 1000000000000) * pow(cos(Chain1Angle),2) * pow(Chain1Straight,2) * pow((tan(Chain2Angle) * cos(Chain1Angle)) + sin(Chain1Angle),2)));
     Chain2Straight *= (1 + ((sysSettings.chainSagCorrection / 1000000000000) * pow(cos(Chain2Angle),2) * pow(Chain2Straight,2) * pow((tan(Chain1Angle) * cos(Chain2Angle)) + sin(Chain2Angle),2)));
 
     //Calculate total chain lengths accounting for sprocket geometry and chain sag
-    float Chain1 = Chain1AroundSprocket + Chain1Straight;
-    float Chain2 = Chain2AroundSprocket + Chain2Straight;
+    float Chain1 = Chain1AroundSprocket + Chain1Straight * leftChainTolerance;
+    float Chain2 = Chain2AroundSprocket + Chain2Straight * rightChainTolerance;
 
     //Subtract of the virtual length which is added to the chain by the rotation mechanism
     Chain1 = Chain1 - sysSettings.rotationDiskRadius;

--- a/cnc_ctrl_v1/Kinematics.cpp
+++ b/cnc_ctrl_v1/Kinematics.cpp
@@ -59,8 +59,6 @@ void Kinematics::recomputeGeometry(){
     _xCordOfMotor = sysSettings.distBetweenMotors/2;
     _yCordOfMotor = halfHeight + sysSettings.motorOffsetY;
 
-    leftChainTolerance = sysSettings.distPerRot/sysSettings.distPerRotLeftChainTolerance;
-    rightChainTolerance = sysSettings.distPerRot/sysSettings.distPerRotRightChainTolerance;
 }
 
 void  Kinematics::inverse(float xTarget,float yTarget, float* aChainLength, float* bChainLength){
@@ -238,8 +236,8 @@ void  Kinematics::triangularInverse(float xTarget,float yTarget, float* aChainLe
     Chain2Straight *= (1 + ((sysSettings.chainSagCorrection / 1000000000000) * pow(cos(Chain2Angle),2) * pow(Chain2Straight,2) * pow((tan(Chain1Angle) * cos(Chain2Angle)) + sin(Chain2Angle),2)));
 
     //Calculate total chain lengths accounting for sprocket geometry and chain sag
-    float Chain1 = Chain1AroundSprocket + Chain1Straight * leftChainTolerance;
-    float Chain2 = Chain2AroundSprocket + Chain2Straight * rightChainTolerance;
+    float Chain1 = Chain1AroundSprocket + Chain1Straight * (1.0f + sysSettings.leftChainTolerance / 100.0f);
+    float Chain2 = Chain2AroundSprocket + Chain2Straight * (1.0f + sysSettings.rightChainTolerance / 100.0f);
 
     //Subtract of the virtual length which is added to the chain by the rotation mechanism
     Chain1 = Chain1 - sysSettings.rotationDiskRadius;

--- a/cnc_ctrl_v1/Kinematics.h
+++ b/cnc_ctrl_v1/Kinematics.h
@@ -39,8 +39,8 @@
             float h; //distance between sled attach point and bit
             float R             = 10.1;                                //sprocket radius
 
-            float leftChainTolerance = 1;
-            float rightChainTolerance = 1;
+            float leftChainTolerance = 0;
+            float rightChainTolerance = 0;
 
             float halfWidth;                      //Half the machine width
             float halfHeight;                    //Half the machine height

--- a/cnc_ctrl_v1/Kinematics.h
+++ b/cnc_ctrl_v1/Kinematics.h
@@ -39,9 +39,6 @@
             float h; //distance between sled attach point and bit
             float R             = 10.1;                                //sprocket radius
 
-            float leftChainTolerance = 0;
-            float rightChainTolerance = 0;
-
             float halfWidth;                      //Half the machine width
             float halfHeight;                    //Half the machine height
         private:

--- a/cnc_ctrl_v1/Kinematics.h
+++ b/cnc_ctrl_v1/Kinematics.h
@@ -38,10 +38,9 @@
             //geometry
             float h; //distance between sled attach point and bit
             float R             = 10.1;                                //sprocket radius
-            float RleftChainTolerance = 10.1;    // Left sprocket radius including chain tolerance
-            float RrightChainTolerance = 10.1;    // Right sprocket radius including chain tolerance
-            
 
+            float leftChainTolerance = 1;
+            float rightChainTolerance = 1;
 
             float halfWidth;                      //Half the machine width
             float halfHeight;                    //Half the machine height

--- a/cnc_ctrl_v1/Report.cpp
+++ b/cnc_ctrl_v1/Report.cpp
@@ -179,8 +179,8 @@ void reportMaslowSettings() {
     Serial.print(F("$37=")); Serial.println(sysSettings.chainSagCorrection, 8);
     Serial.print(F("$38=")); Serial.println(sysSettings.chainOverSprocket);
     Serial.print(F("$39=")); Serial.println(sysSettings.fPWM);
-    Serial.print(F("$40=")); Serial.println(sysSettings.distPerRotLeftChainTolerance, 8);
-    Serial.print(F("$41=")); Serial.println(sysSettings.distPerRotRightChainTolerance, 8);
+    Serial.print(F("$40=")); Serial.println(sysSettings.leftChainTolerance, 8);
+    Serial.print(F("$41=")); Serial.println(sysSettings.rightChainTolerance, 8);
     Serial.print(F("$42=")); Serial.println(sysSettings.positionErrorLimit, 8);
     
   #else
@@ -223,9 +223,9 @@ void reportMaslowSettings() {
     Serial.print(F(" (z axis Velocity proportional weight)\r\n$37=")); Serial.print(sysSettings.chainSagCorrection, 8);
     Serial.print(F(" (chain sag correction value)\r\n$38=")); Serial.print(sysSettings.chainOverSprocket);
     Serial.print(F(" (chain over sprocket)\r\n$39=")); Serial.print(sysSettings.fPWM);
-    Serial.print(F(" (PWM frequency value 1=39,000Hz, 2=4,100Hz, 3=490Hz)\r\n$40=")); Serial.print(sysSettings.distPerRotLeftChainTolerance, 8);
-    Serial.print(F(" (distance / rotation, including chain tolerance, left chain, mm)\r\n$41=")); Serial.print(sysSettings.distPerRotRightChainTolerance, 8);
-    Serial.print(F(" (distance / rotation, including chain tolerance, right chain, mm)\r\n$42=")); Serial.print(sysSettings.positionErrorLimit, 8);
+    Serial.print(F(" (PWM frequency value 1=39,000Hz, 2=4,100Hz, 3=490Hz)\r\n$40=")); Serial.print(sysSettings.leftChainTolerance, 8);
+    Serial.print(F(" (chain tolerance, left chain, mm)\r\n$41=")); Serial.print(sysSettings.rightChainTolerance, 8);
+    Serial.print(F(" (chain tolerance, right chain, mm)\r\n$42=")); Serial.print(sysSettings.positionErrorLimit, 8);
     Serial.print(F(" (position error alarm limit, mm)"));
     Serial.println();
   #endif

--- a/cnc_ctrl_v1/Settings.cpp
+++ b/cnc_ctrl_v1/Settings.cpp
@@ -49,8 +49,8 @@ void settingsLoadFromEEprom(){
     kinematics.recomputeGeometry();
     leftAxis.changeEncoderResolution(&sysSettings.encoderSteps);
     rightAxis.changeEncoderResolution(&sysSettings.encoderSteps);
-    leftAxis.changePitch(&sysSettings.distPerRotLeftChainTolerance);
-    rightAxis.changePitch(&sysSettings.distPerRotRightChainTolerance);
+    leftAxis.changePitch(&sysSettings.distPerRot);
+    rightAxis.changePitch(&sysSettings.distPerRot);
     zAxis.changePitch(&sysSettings.zDistPerRot);
     zAxis.changeEncoderResolution(&sysSettings.zEncoderSteps);
 }
@@ -399,13 +399,11 @@ byte settingsStoreGlobalSetting(const byte& parameter,const float& value){
               break;
         case 40:
               sysSettings.distPerRotLeftChainTolerance = value;
-              leftAxis.changePitch(&sysSettings.distPerRotLeftChainTolerance);
-              kinematics.RleftChainTolerance = (sysSettings.distPerRotLeftChainTolerance)/(2.0 * 3.14159);
+              kinematics.recomputeGeometry();
               break;
         case 41:
               sysSettings.distPerRotRightChainTolerance = value;
-              rightAxis.changePitch(&sysSettings.distPerRotRightChainTolerance);
-              kinematics.RrightChainTolerance = (sysSettings.distPerRotRightChainTolerance)/(2.0 * 3.14159);
+              kinematics.recomputeGeometry();
               break;
         case 42:
               sysSettings.positionErrorLimit = value;

--- a/cnc_ctrl_v1/Settings.cpp
+++ b/cnc_ctrl_v1/Settings.cpp
@@ -102,8 +102,8 @@ void settingsReset() {
     sysSettings.chainSagCorrection = 0.0;  // float chainSagCorrection;
     sysSettings.chainOverSprocket = 1;   // byte chainOverSprocket;
     sysSettings.fPWM = 3;   // byte fPWM;
-    sysSettings.distPerRotLeftChainTolerance = 63.5;    // float distPerRotLeftChainTolerance;
-    sysSettings.distPerRotRightChainTolerance = 63.5;    // float distPerRotRightChainTolerance;
+    sysSettings.leftChainTolerance = 0.0;    // float leftChainTolerance;
+    sysSettings.rightChainTolerance = 0.0;    // float rightChainTolerance;
     sysSettings.positionErrorLimit = 2.0;  // float positionErrorLimit;
     sysSettings.eepromValidData = EEPROMVALIDDATA; // byte eepromValidData;
 }
@@ -398,12 +398,10 @@ byte settingsStoreGlobalSetting(const byte& parameter,const float& value){
               setPWMPrescalers(value);
               break;
         case 40:
-              sysSettings.distPerRotLeftChainTolerance = value;
-              kinematics.recomputeGeometry();
+              sysSettings.leftChainTolerance = value;
               break;
         case 41:
-              sysSettings.distPerRotRightChainTolerance = value;
-              kinematics.recomputeGeometry();
+              sysSettings.rightChainTolerance = value;
               break;
         case 42:
               sysSettings.positionErrorLimit = value;

--- a/cnc_ctrl_v1/Settings.h
+++ b/cnc_ctrl_v1/Settings.h
@@ -20,7 +20,7 @@ Copyright 2014-2017 Bar Smith*/
 #ifndef settings_h
 #define settings_h
 
-#define SETTINGSVERSION 4      // The current version of settings, if this doesn't
+#define SETTINGSVERSION 5      // The current version of settings, if this doesn't
                                // match what is in EEPROM then settings on
                                // machine are reset to defaults
 #define EEPROMVALIDDATA 56     // This is just a random byte value that is used 

--- a/cnc_ctrl_v1/Settings.h
+++ b/cnc_ctrl_v1/Settings.h
@@ -78,8 +78,8 @@ typedef struct {  // I think this is about ~128 bytes in size if I counted corre
   float chainSagCorrection;
   byte chainOverSprocket;
   byte fPWM;
-  float distPerRotLeftChainTolerance;
-  float distPerRotRightChainTolerance;
+  float leftChainTolerance;
+  float rightChainTolerance;
   float positionErrorLimit;
   byte eepromValidData;  // This should always be last, that way if an error
                          // happens in writing, it will not be written and we


### PR DESCRIPTION
This is another bit of code I found in @madgrizzle's development branch. I believe this to be a solid simplification of how the chain tolerance correction works.

In the current system, GroundControl accepts a positive or negative percentage adjustment to adjust the chain tolerance for each chain (e.g. 1.3% if your chain is 1.3% longer than expected), it then turns that into a calculated value for `distPerRotLeftChainTolerance` by multiplying the adjustment by `distPerRot`. That value is then sent to the firmware, where it is divided by `2*Pi` and stored as `RleftChainTolerance`. It's then used in place of the sprocket radius `R` in the firmware for all calculations that involve the sprocket's radius.

With this change, GroundControl continues to accept a positive or negative percentage adjustment for each chain (current settings will continue to work), but does no calculation on that value. Then that adjustment is sent to the firmware as `leftChainTolerance`. That tolerance value is simply multiplied by the calculated chain length to derive the adjusted chain length.

Additionally, I think this is maybe _slightly_ more accurate. The current chain tolerance adjustment adjusts for the bit of chain that is still on the sprocket (`Chain1AroundSprocket`). I _think_ the length of the chain around the sprocket is a function of the radius of the sprocket, and not the tolerance in the chain, though it's likely not a big enough value to matter one way or another. It's trivial to make this change account for that as well.

The corresponding GroundControl change is MaslowCNC/GroundControl#783
Discussion in the forums is here: https://forums.maslowcnc.com/t/simplified-chain-tolerance-correction-pull-request/7395