### PR TITLE
Experimental optical calibration support

### DIFF
--- a/cnc_ctrl_v1/Calibration.cpp
+++ b/cnc_ctrl_v1/Calibration.cpp
@@ -1,0 +1,59 @@
+/*This file is part of the Maslow Control Software.
+
+The Maslow Control Software is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Maslow Control Software is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with the Maslow Control Software.  If not, see <http://www.gnu.org/licenses/>.
+
+Copyright 2014-2017 Bar Smith*/
+
+// This file contains the machine settings that are saved to eeprom
+
+// EEPROM addresses 300 and up can be used by Maslow.  Under 300 was used
+// previously by pre v1.00 Firmware.
+
+#include "Maslow.h"
+#include <EEPROM.h>
+
+void initializeCalibration(){
+    /*
+    initializes the data to zero
+    */
+    Serial.print(F(" Zeroing Calibration\r\n"));
+    for (int x=0; x<31; x++){
+      for (int y=0; y<15; y++){
+        calibration.xError[x][y]=0;
+        calibration.yError[x][y]=0;
+      }
+    }
+}
+
+byte calibrationUpdateMatrix(int _x, int _y, int xValue, int yValue) {
+  if ( (_x==31) && (_y==15) )
+  {
+    settingsSaveToEEprom();
+    return(STATUS_OK);
+  }
+  else
+  {
+    if ( (_x>=0) && (_x<31) ) {
+      if ( (_y>=0) && (_y<15) ){
+          calibration.xError[_x][_y]=xValue;
+          calibration.yError[_x][_y]=yValue;
+          if ((_x==15) && (_y==7)){
+            kinematics.init();
+          }
+          return(STATUS_OK);
+      }
+    }
+    return(STATUS_INVALID_STATEMENT);
+  }
+}

--- a/cnc_ctrl_v1/Calibration.cpp
+++ b/cnc_ctrl_v1/Calibration.cpp
@@ -15,44 +15,31 @@ along with the Maslow Control Software.  If not, see <http://www.gnu.org/license
 
 Copyright 2014-2017 Bar Smith*/
 
-// This file contains the machine settings that are saved to eeprom
-
-// EEPROM addresses 300 and up can be used by Maslow.  Under 300 was used
-// previously by pre v1.00 Firmware.
-
 #include "Maslow.h"
 #include <EEPROM.h>
 
-void initializeCalibration(){
-    /*
-    initializes the data to zero
-    */
-    Serial.print(F(" Zeroing Calibration\r\n"));
-    for (int x=0; x<31; x++){
-      for (int y=0; y<15; y++){
-        calibration.xError[x][y]=0;
-        calibration.yError[x][y]=0;
-      }
+void initializeCalibration() {
+  Serial.print(F("Zeroing Calibration\r\n"));
+  for (int x=0; x<31; x++) {
+    for (int y=0; y<15; y++) {
+      calibration.xError[x][y] = 0;
+      calibration.yError[x][y] = 0;
     }
+  }
 }
 
-byte calibrationUpdateMatrix(int _x, int _y, int xValue, int yValue) {
-  if ( (_x==31) && (_y==15) )
-  {
+byte calibrationUpdateMatrix(int x, int y, int xValue, int yValue) {
+  if ((x==31) && (y==15)) {
     settingsSaveToEEprom();
     return(STATUS_OK);
-  }
-  else
-  {
-    if ( (_x>=0) && (_x<31) ) {
-      if ( (_y>=0) && (_y<15) ){
-          calibration.xError[_x][_y]=xValue;
-          calibration.yError[_x][_y]=yValue;
-          if ((_x==15) && (_y==7)){
-            kinematics.init();
-          }
-          return(STATUS_OK);
+  } else {
+    if (((x>=0) && (x<31)) && ((y>=0) && (y<15))) {
+      calibration.xError[x][y] = xValue;
+      calibration.yError[x][y] = yValue;
+      if ((x==15) && (y==7)) {
+        kinematics.init();
       }
+      return(STATUS_OK);
     }
     return(STATUS_INVALID_STATEMENT);
   }

--- a/cnc_ctrl_v1/Calibration.h
+++ b/cnc_ctrl_v1/Calibration.h
@@ -15,19 +15,21 @@ along with the Maslow Control Software.  If not, see <http://www.gnu.org/license
 
 Copyright 2014-2017 Bar Smith*/
 
-// This file contains helper functions that are used throughout
+// This file contains the machine settings that are saved to eeprom
 
-#ifndef nutsandbolts_h
-#define nutsandbolts_h
+#ifndef calibration_h
+#define calibration_h
 
-// These are nifty functions from Grbl
-#define bit_true(x,mask) (x) |= (mask)
-#define bit_false(x,mask) (x) &= ~(mask)
-#define bit_istrue(x,mask) ((x & mask) != 0)
-#define bit_isfalse(x,mask) ((x & mask) == 0)
+typedef struct {
+  int xError[31][15]; // these are ints to save memory.  each represent 0.001 mm so maximum error is +/~32 mm which is crazy high still
+  int yError[31][15]; // these are ints to save memory.  each represent 0.001 mm so maximum error is +/~32 mm which is crazy high still
+  //float leftLength[31][15]; //Need more memory
+  //float rightLength[31][15]; //Need more memory
+} calibration_t;
+extern calibration_t calibration;
 
-float readFloat(const String&, byte&, float&);
-float readFullFloat(const String&, byte&, float&);
-float readArrayValue(const String&, byte&, int&, int&, int&, int&);
 
-#endif 
+void initializeCalibration();
+byte calibrationUpdateMatrix(const int, const int, const int, const int);
+
+#endif

--- a/cnc_ctrl_v1/Calibration.h
+++ b/cnc_ctrl_v1/Calibration.h
@@ -15,21 +15,21 @@ along with the Maslow Control Software.  If not, see <http://www.gnu.org/license
 
 Copyright 2014-2017 Bar Smith*/
 
-// This file contains the machine settings that are saved to eeprom
-
 #ifndef calibration_h
 #define calibration_h
 
 typedef struct {
-  int xError[31][15]; // these are ints to save memory.  each represent 0.001 mm so maximum error is +/~32 mm which is crazy high still
-  int yError[31][15]; // these are ints to save memory.  each represent 0.001 mm so maximum error is +/~32 mm which is crazy high still
-  //float leftLength[31][15]; //Need more memory
-  //float rightLength[31][15]; //Need more memory
+  // These are int to save memory. Each represents 0.001 mm so maximum error is +/~32 mm
+  int xError[31][15];
+  int yError[31][15];
 } calibration_t;
 extern calibration_t calibration;
 
-
+/*
+initializes the data to zero
+*/
 void initializeCalibration();
-byte calibrationUpdateMatrix(const int, const int, const int, const int);
+
+byte calibrationUpdateMatrix(const int x, const int y, const int xValue, const int yValue);
 
 #endif

--- a/cnc_ctrl_v1/Kinematics.cpp
+++ b/cnc_ctrl_v1/Kinematics.cpp
@@ -61,8 +61,8 @@ void Kinematics::recomputeGeometry(){
 
     float xOffset = 0.0;
     float yOffset = 0.0;
-    if (sysSettings.enableOpticalCalibration==true){
-        if (sysSettings.useInterpolationOrCurve==true){
+    if (sysSettings.enableOpticalCalibration) {
+        if (sysSettings.useInterpolationOrCurve) {
             xOffset = (float)calibration.xError[15][7]/1000.0;
             yOffset = (float)calibration.yError[15][7]/1000.0;
         } else {
@@ -200,11 +200,11 @@ void  Kinematics::quadrilateralInverse(float xTarget,float yTarget, float* aChai
 
 }
 
-void Kinematics::_adjustTarget(float* xTarget,float* yTarget){
+void Kinematics::_adjustTarget(float* xTarget,float* yTarget) {
     if (sysSettings.useInterpolationOrCurve) {
         // shift target to 0,0 being top left corner to match array and convert to inches because array is based on inches.. divide by 3 because array is 3 inches apart and subtact 1 because array starts at 3 inch, 3 inch
-        float x = (*xTarget + sysSettings.machineWidth/2.0)/25.4/3.0-1.0;
-        float y = (sysSettings.machineHeight/2.0 - *yTarget)/25.4/3.0-1.0;
+        float x = (*xTarget + sysSettings.machineWidth/2.0) / 25.4 / 3.0 - 1.0;
+        float y = (sysSettings.machineHeight/2.0 - *yTarget) / 25.4 / 3.0 - 1.0;
         // get x1,y1 and x2, y2 for interpolation
         int x1 = (int)(x);
         int y1 = (int)(y);

--- a/cnc_ctrl_v1/Kinematics.h
+++ b/cnc_ctrl_v1/Kinematics.h
@@ -47,6 +47,7 @@
             void  _MatSolv();
             void  _MyTrig();
             void _verifyValidTarget(float* xTarget,float* yTarget);
+            void _adjustTarget(float* xTarget,float* yTarget);
             //target router bit coordinates.
             float x = 0;
             float y = 0;

--- a/cnc_ctrl_v1/Maslow.h
+++ b/cnc_ctrl_v1/Maslow.h
@@ -45,6 +45,7 @@
 #include "Spindle.h"
 #include "Probe.h"
 #include "Settings.h"
+#include "Calibration.h"
 #include "NutsAndBolts.h"
 #include "System.h"
 #include "SimavrSerial.h"

--- a/cnc_ctrl_v1/Motion.cpp
+++ b/cnc_ctrl_v1/Motion.cpp
@@ -77,13 +77,6 @@ int   coordinatedMove(const float& xEnd, const float& yEnd, const float& zEnd, f
     the speed moveSpeed. Movements are correlated so that regardless of the distances moved in each 
     direction, the tool moves to the target in a straight line. This function is used by the G00 
     and G01 commands. The units at this point should all be in mm or mm per minute*/
-    if (sysSettings.enableOpticalCalibration){
-        if (sysSettings.useInterpolationOrCurve) {
-            Serial.println("move adjusted by interpolation");
-        } else {
-            Serial.println("move adjusted by curve");
-        }
-    }
     
     float  xStartingLocation = sys.xPosition;
     float  yStartingLocation = sys.yPosition;

--- a/cnc_ctrl_v1/Motion.cpp
+++ b/cnc_ctrl_v1/Motion.cpp
@@ -77,6 +77,13 @@ int   coordinatedMove(const float& xEnd, const float& yEnd, const float& zEnd, f
     the speed moveSpeed. Movements are correlated so that regardless of the distances moved in each 
     direction, the tool moves to the target in a straight line. This function is used by the G00 
     and G01 commands. The units at this point should all be in mm or mm per minute*/
+    if (sysSettings.enableOpticalCalibration){
+        if (sysSettings.useInterpolationOrCurve) {
+            Serial.println("move adjusted by interpolation");
+        } else {
+            Serial.println("move adjusted by curve");
+        }
+    }
     
     float  xStartingLocation = sys.xPosition;
     float  yStartingLocation = sys.yPosition;

--- a/cnc_ctrl_v1/NutsAndBolts.cpp
+++ b/cnc_ctrl_v1/NutsAndBolts.cpp
@@ -66,47 +66,45 @@ float readFloat(const String& str, byte& index, float& retVal){
     return true;
 }
 
-float readArrayValue(const String& str, byte& index, int& x, int& y, int& xValue, int& yValue){
-    /*
-    Don't mind scientific notation here..  no big whoop
-    */
-    //remove any spaces or eqals before start of parsing
-    //Serial.println(str);
-    while ( ( (str[index] == ' ') || (str[index] == '=') ) && index < str.length()){
+float readArrayValue(const String& str, byte& index, int& x, int& y, int& xValue, int& yValue) {
+    // Don't mind scientific notation here..  no big whoop
+
+    // Remove any spaces or eqals before start of parsing
+    while (((str[index] == ' ') || (str[index] == '=')) && index < str.length()) {
       index++;
     }
+
     // parse out based upon commands
     // make it easy.. parse xS, parse yS, parse xValueS, parse yValueS
     String xS = "";
-    while ((index<str.length()) && (str[index]!=',') ){
+    while ((index < str.length()) && (str[index] != ',')) {
       xS.concat(str[index]);
       index++;
     }
     index++; // get past the comma
 
     String yS = "";
-    while ((index<str.length()) && (str[index]!=',') ){
+    while ((index < str.length()) && (str[index] != ',')) {
       yS.concat(str[index]);
       index++;
     }
     index++; // get past the comma
 
     String xValueS = "";
-    while ((index<str.length()) && (str[index]!=',') ){
+    while ((index < str.length()) && (str[index] != ',')) {
       xValueS.concat(str[index]);
       index++;
     }
     index++; // get past the comma
 
     String yValueS = "";
-    while ((index<str.length()) && (str[index]!=',') ){
+    while ((index < str.length()) && (str[index] != ',')) {
       yValueS.concat(str[index]);
       index++;
     }
     index++; // get past the comma
 
-
-    //now convert to Values
+    // now convert to Values
     x = xS.toInt();
     y = yS.toInt();
     xValue = xValueS.toInt();
@@ -115,9 +113,7 @@ float readArrayValue(const String& str, byte& index, int& x, int& y, int& xValue
     return true;
 }
 
-
-float readFullFloat(const String& str, byte& index, float& retVal){
-
+float readFullFloat(const String& str, byte& index, float& retVal) {
     String sub = str.substring(index);
     sub.trim();
     retVal = sub.toFloat();

--- a/cnc_ctrl_v1/NutsAndBolts.cpp
+++ b/cnc_ctrl_v1/NutsAndBolts.cpp
@@ -65,3 +65,61 @@ float readFloat(const String& str, byte& index, float& retVal){
 
     return true;
 }
+
+float readArrayValue(const String& str, byte& index, int& x, int& y, int& xValue, int& yValue){
+    /*
+    Don't mind scientific notation here..  no big whoop
+    */
+    //remove any spaces or eqals before start of parsing
+    //Serial.println(str);
+    while ( ( (str[index] == ' ') || (str[index] == '=') ) && index < str.length()){
+      index++;
+    }
+    // parse out based upon commands
+    // make it easy.. parse xS, parse yS, parse xValueS, parse yValueS
+    String xS = "";
+    while ((index<str.length()) && (str[index]!=',') ){
+      xS.concat(str[index]);
+      index++;
+    }
+    index++; // get past the comma
+
+    String yS = "";
+    while ((index<str.length()) && (str[index]!=',') ){
+      yS.concat(str[index]);
+      index++;
+    }
+    index++; // get past the comma
+
+    String xValueS = "";
+    while ((index<str.length()) && (str[index]!=',') ){
+      xValueS.concat(str[index]);
+      index++;
+    }
+    index++; // get past the comma
+
+    String yValueS = "";
+    while ((index<str.length()) && (str[index]!=',') ){
+      yValueS.concat(str[index]);
+      index++;
+    }
+    index++; // get past the comma
+
+
+    //now convert to Values
+    x = xS.toInt();
+    y = yS.toInt();
+    xValue = xValueS.toInt();
+    yValue = yValueS.toInt();
+
+    return true;
+}
+
+
+float readFullFloat(const String& str, byte& index, float& retVal){
+
+    String sub = str.substring(index);
+    sub.trim();
+    retVal = sub.toFloat();
+    return true;
+}

--- a/cnc_ctrl_v1/Report.cpp
+++ b/cnc_ctrl_v1/Report.cpp
@@ -182,6 +182,20 @@ void reportMaslowSettings() {
     Serial.print(F("$40=")); Serial.println(sysSettings.leftChainTolerance, 8);
     Serial.print(F("$41=")); Serial.println(sysSettings.rightChainTolerance, 8);
     Serial.print(F("$42=")); Serial.println(sysSettings.positionErrorLimit, 8);
+    Serial.print(F("$44=")); Serial.println(sysSettings.enableOpticalCalibration, 8);
+    Serial.print(F("$46=")); Serial.println(sysSettings.useInterpolationOrCurve, 8);
+    Serial.print(F("$47=")); Serial.println(sysSettings.calX0, 8);
+    Serial.print(F("$48=")); Serial.println(sysSettings.calX1, 8);
+    Serial.print(F("$49=")); Serial.println(sysSettings.calX2, 8);
+    Serial.print(F("$50=")); Serial.println(sysSettings.calX3, 8);
+    Serial.print(F("$51=")); Serial.println(sysSettings.calX4, 8);
+    Serial.print(F("$52=")); Serial.println(sysSettings.calX5, 8);
+    Serial.print(F("$53=")); Serial.println(sysSettings.calY0, 8);
+    Serial.print(F("$54=")); Serial.println(sysSettings.calY1, 8);
+    Serial.print(F("$55=")); Serial.println(sysSettings.calY2, 8);
+    Serial.print(F("$56=")); Serial.println(sysSettings.calY3, 8);
+    Serial.print(F("$57=")); Serial.println(sysSettings.calY4, 8);
+    Serial.print(F("$58=")); Serial.println(sysSettings.calY5, 8);
     
   #else
     Serial.print(F("$0=")); Serial.print(sysSettings.machineWidth);
@@ -226,7 +240,23 @@ void reportMaslowSettings() {
     Serial.print(F(" (PWM frequency value 1=39,000Hz, 2=4,100Hz, 3=490Hz)\r\n$40=")); Serial.print(sysSettings.leftChainTolerance, 8);
     Serial.print(F(" (chain tolerance, left chain, mm)\r\n$41=")); Serial.print(sysSettings.rightChainTolerance, 8);
     Serial.print(F(" (chain tolerance, right chain, mm)\r\n$42=")); Serial.print(sysSettings.positionErrorLimit, 8);
-    Serial.print(F(" (position error alarm limit, mm)"));
+    Serial.print(F(" (position error alarm limit, mm)")); Serial.print(calibration.xError[15][7]);
+    Serial.print(F(" (Center X Error, mm)\r\n")); Serial.print(calibration.yError[15][7]);
+    Serial.print(F(" (Center Y Error, mm)\r\n")); Serial.print(sysSettings.enableOpticalCalibration);
+    Serial.print(F(" (enable calibration)\r\n")); Serial.print(sysSettings.useInterpolationOrCurve);
+    Serial.print(F(" (use interp or curve)\r\n")); Serial.print(sysSettings.calX0);
+    Serial.print(F(" (calX0)\r\n")); Serial.print(sysSettings.calX1,8);
+    Serial.print(F(" (calX1)\r\n")); Serial.print(sysSettings.calX2,8);
+    Serial.print(F(" (calX2)\r\n")); Serial.print(sysSettings.calX3,8);
+    Serial.print(F(" (calX3)\r\n")); Serial.print(sysSettings.calX4,8);
+    Serial.print(F(" (calX4)\r\n")); Serial.print(sysSettings.calX5,8);
+    Serial.print(F(" (calX5)\r\n")); Serial.print(sysSettings.calY0,8);
+    Serial.print(F(" (calY0)\r\n")); Serial.print(sysSettings.calY1,8);
+    Serial.print(F(" (calY1)\r\n")); Serial.print(sysSettings.calY2,8);
+    Serial.print(F(" (calY2)\r\n")); Serial.print(sysSettings.calY3,8);
+    Serial.print(F(" (calY3)\r\n")); Serial.print(sysSettings.calY4,8);
+    Serial.print(F(" (calY4)\r\n")); Serial.print(sysSettings.calY5,8);
+    Serial.print(F(" (calY5)\r\n"));
     Serial.println();
   #endif
 }

--- a/cnc_ctrl_v1/Settings.cpp
+++ b/cnc_ctrl_v1/Settings.cpp
@@ -35,7 +35,7 @@ void settingsLoadFromEEprom(){
     settingsReset(); // Load default values first
     EEPROM.get(300, settingsVersionStruct);
     EEPROM.get(340, tempSettings);
-    EEPROM.get(2048, calibration);  // error check this?
+    EEPROM.get(2048, calibration);
     if (settingsVersionStruct.settingsVersion == SETTINGSVERSION &&
         settingsVersionStruct.eepromValidData == EEPROMVALIDDATA &&
         tempSettings.eepromValidData == EEPROMVALIDDATA){
@@ -140,7 +140,7 @@ void settingsWipe(byte resetType){
       EEPROM.write(i, 0);
     }
   }
-  else if (bit_istrue(resetType, SETTINGS_RESTORE_CALIBRATION)){
+  else if (bit_istrue(resetType, SETTINGS_RESTORE_CALIBRATION)) {
     for (size_t i = 2048 ; i < sizeof(calibration) + 2048; i++) {
       EEPROM.write(i, 0);
     }

--- a/cnc_ctrl_v1/Settings.h
+++ b/cnc_ctrl_v1/Settings.h
@@ -20,7 +20,7 @@ Copyright 2014-2017 Bar Smith*/
 #ifndef settings_h
 #define settings_h
 
-#define SETTINGSVERSION 5      // The current version of settings, if this doesn't
+#define SETTINGSVERSION 6      // The current version of settings, if this doesn't
                                // match what is in EEPROM then settings on
                                // machine are reset to defaults
 #define EEPROMVALIDDATA 56     // This is just a random byte value that is used 
@@ -31,6 +31,7 @@ Copyright 2014-2017 Bar Smith*/
 #define SETTINGS_RESTORE_SETTINGS bit(0)
 #define SETTINGS_RESTORE_MASLOW bit(1)
 #define SETTINGS_RESTORE_ALL bit(2)
+#define SETTINGS_RESTORE_CALIBRATION bit(3)
 
 enum SpindleAutomationType {
   NONE,
@@ -81,6 +82,20 @@ typedef struct {  // I think this is about ~128 bytes in size if I counted corre
   float leftChainTolerance;
   float rightChainTolerance;
   float positionErrorLimit;
+  bool enableOpticalCalibration;
+  bool useInterpolationOrCurve;
+  float calX0;
+  float calX1;
+  float calX2;
+  float calX3;
+  float calX4;
+  float calX5;
+  float calY0;
+  float calY1;
+  float calY2;
+  float calY3;
+  float calY4;
+  float calY5;
   byte eepromValidData;  // This should always be last, that way if an error
                          // happens in writing, it will not be written and we
 } settings_t;            // will know to reset the settings

--- a/cnc_ctrl_v1/System.cpp
+++ b/cnc_ctrl_v1/System.cpp
@@ -437,7 +437,6 @@ byte systemExecuteCmdstring(String& cmdString){
     byte char_counter = 1;
 //    byte helper_var = 0; // Helper variable
     float parameter, value;
-    int _x, _y, xValue, yValue;
     if (cmdString.length() == 1){
         reportMaslowHelp();
     }
@@ -568,10 +567,9 @@ byte systemExecuteCmdstring(String& cmdString){
           //         // No break. Continues into default: to read remaining command characters.
           //       }
               case 'O' : // Here's were we can send customized data that doesn't fit the firmwareKey/floating
-                //Serial.println("received");
-                if(!readArrayValue(cmdString, ++char_counter, _x, _y, xValue, yValue)) {return(STATUS_BAD_NUMBER_FORMAT); }
-                return(calibrationUpdateMatrix(_x, _y, xValue, yValue));
-                break;
+                int x, y, xValue, yValue;
+                if (!readArrayValue(cmdString, ++char_counter, x, y, xValue, yValue)) { return(STATUS_BAD_NUMBER_FORMAT); }
+                return(calibrationUpdateMatrix(x, y, xValue, yValue));
               default :  // Storing setting methods [IDLE/ALARM]
                 if(!readFloat(cmdString, char_counter, parameter)) { return(STATUS_BAD_NUMBER_FORMAT); }
                 if(cmdString[char_counter++] != '=') { return(STATUS_INVALID_STATEMENT); }
@@ -590,11 +588,10 @@ byte systemExecuteCmdstring(String& cmdString){
                 //   }
                 // } else { // Store global setting.
                 if ((parameter>=47) && (parameter<=58)) {
-                    if (!readFullFloat(cmdString, char_counter, value)) { return(STATUS_BAD_NUMBER_FORMAT);}
-                }
-                else {
-                    if(!readFloat(cmdString, char_counter, value)) { return(STATUS_BAD_NUMBER_FORMAT); }
-                    if((cmdString[char_counter] != 0) || (parameter > 255)) { return(STATUS_INVALID_STATEMENT); }
+                    if (!readFullFloat(cmdString, char_counter, value)) { return(STATUS_BAD_NUMBER_FORMAT); }
+                } else {
+                    if (!readFloat(cmdString, char_counter, value)) { return(STATUS_BAD_NUMBER_FORMAT); }
+                    if ((cmdString[char_counter] != 0) || (parameter > 255)) { return(STATUS_INVALID_STATEMENT); }
                 }
                 return(settingsStoreGlobalSetting((byte)parameter, value));
                 // }

--- a/cnc_ctrl_v1/System.cpp
+++ b/cnc_ctrl_v1/System.cpp
@@ -437,6 +437,7 @@ byte systemExecuteCmdstring(String& cmdString){
     byte char_counter = 1;
 //    byte helper_var = 0; // Helper variable
     float parameter, value;
+    int _x, _y, xValue, yValue;
     if (cmdString.length() == 1){
         reportMaslowHelp();
     }
@@ -545,6 +546,7 @@ byte systemExecuteCmdstring(String& cmdString){
                   case '$': settingsWipe(SETTINGS_RESTORE_SETTINGS); break;
                   case '#': settingsWipe(SETTINGS_RESTORE_MASLOW); break;
                   case '*': settingsWipe(SETTINGS_RESTORE_ALL); break;
+                  case '^': settingsWipe(SETTINGS_RESTORE_CALIBRATION); break;
                   default: return(STATUS_INVALID_STATEMENT);
                 }
                 reportFeedbackMessage(MESSAGE_RESTORE_DEFAULTS);
@@ -565,6 +567,11 @@ byte systemExecuteCmdstring(String& cmdString){
           //         helper_var = true;  // Set helper_var to flag storing method.
           //         // No break. Continues into default: to read remaining command characters.
           //       }
+              case 'O' : // Here's were we can send customized data that doesn't fit the firmwareKey/floating
+                //Serial.println("received");
+                if(!readArrayValue(cmdString, ++char_counter, _x, _y, xValue, yValue)) {return(STATUS_BAD_NUMBER_FORMAT); }
+                return(calibrationUpdateMatrix(_x, _y, xValue, yValue));
+                break;
               default :  // Storing setting methods [IDLE/ALARM]
                 if(!readFloat(cmdString, char_counter, parameter)) { return(STATUS_BAD_NUMBER_FORMAT); }
                 if(cmdString[char_counter++] != '=') { return(STATUS_INVALID_STATEMENT); }
@@ -582,9 +589,14 @@ byte systemExecuteCmdstring(String& cmdString){
                 //     settings_store_startup_line(helper_var,line);
                 //   }
                 // } else { // Store global setting.
-                  if(!readFloat(cmdString, char_counter, value)) { return(STATUS_BAD_NUMBER_FORMAT); }
-                  if((cmdString[char_counter] != 0) || (parameter > 255)) { return(STATUS_INVALID_STATEMENT); }
-                  return(settingsStoreGlobalSetting((byte)parameter, value));
+                if ((parameter>=47) && (parameter<=58)) {
+                    if (!readFullFloat(cmdString, char_counter, value)) { return(STATUS_BAD_NUMBER_FORMAT);}
+                }
+                else {
+                    if(!readFloat(cmdString, char_counter, value)) { return(STATUS_BAD_NUMBER_FORMAT); }
+                    if((cmdString[char_counter] != 0) || (parameter > 255)) { return(STATUS_INVALID_STATEMENT); }
+                }
+                return(settingsStoreGlobalSetting((byte)parameter, value));
                 // }
             }
         }

--- a/cnc_ctrl_v1/cnc_ctrl_v1.ino
+++ b/cnc_ctrl_v1/cnc_ctrl_v1.ino
@@ -41,6 +41,9 @@ system_t sys;
 // Define the global settings storage - treat as readonly
 settings_t sysSettings;
 
+// Define the calibration values
+calibration_t calibration;
+
 // Global realtime executor bitflag variable for setting various alarms.
 byte systemRtExecAlarm;  
 


### PR DESCRIPTION
Just wanted to put this out there for discussion and feedback. This is @madgrizzle's optical calibration correction feature from his fork. The two of us have been using it with success. It's caused my cuts to be more accurate than before.

There are two ways optical calibration corrections can work.

1) **Interpolation mode** A correction matrix from 465 calibration points (31 columns, 15 rows) is uploaded into EEPROM. Moves are adjusted by interpolating the error between the points to find the positional error at any position on the board.

2) **Curve fit mode** Curve fit coefficients are calculated by GroundControl based on the results of the calibration. The coefficients are stored into EEPROM. Moves are adjusted by using the curve fit equations to find the positional error at any position on the board.

Forum discussion is [here](https://forums.maslowcnc.com/t/experimental-optical-calibration-pull-request/7557). 

Original Optical Calibration thread is [here](https://forums.maslowcnc.com/t/optical-calibration-demo-and-three-hours-working-on-a-bug/6733).