### PR TITLE
Correct angle calculation

### DIFF
--- a/cnc_ctrl_v1/Motion.cpp
+++ b/cnc_ctrl_v1/Motion.cpp
@@ -326,7 +326,7 @@ int   arc(const float& X1, const float& Y1, const float& Z1, const float& X2, co
             
             degreeComplete = float(numberOfStepsTaken)/float(finalNumberOfSteps);
             
-            angleNow = startingAngle + theta*direction*degreeComplete;
+            angleNow = startingAngle + theta*degreeComplete;
             
             sys.xPosition = radius * cos(angleNow) + centerX;
             sys.yPosition = radius * sin(angleNow) + centerY;


### PR DESCRIPTION
This PR addresses Issue #476: "Motion:arc() bug - G2 gcode cuts counterclockwise instead of clockwise"

The variable _**theta**_ used in the incremental motion calculation is defined to contain the value _**direction**_ indicated by G2/G3. This PR removes a second reference to _**direction**_ in that calculation to correct the issue that arises when a negative direction multiplied twice (G2 instance) cancels the direction. The effect was that G2 gcodes cut in the positive direction (as G3 does) instead of the correct direction.

Here is a cut that demonstrates the error and the fix. It should run a 1" counterclockwise circle (G3) to the right of home, with Z beginning at 0 and ending at 0.5, then a clockwise circle (G2) to the left of home with Z finishing at 0. Without the patch, the G2 circle runs counterclockwise.
```
G20 G90
G0 X0 Y0 Z0
G3 X.0 Y0.001 Z-0.5 I1.0 J0.0 F100
G0 X0 Y0
G2 X.0 Y0.001 Z0.0 I-1.0 J0.0 F100
G0 X0 Y0
M2
```