### PR TITLE
Chain length calculation improvement: stretch compensation 

### DIFF
--- a/cnc_ctrl_v1/Kinematics.cpp
+++ b/cnc_ctrl_v1/Kinematics.cpp
@@ -73,15 +73,15 @@ void  Kinematics::inverse(float xTarget,float yTarget, float* aChainLength, floa
     _verifyValidTarget(&xTarget, &yTarget);
     
     if(sysSettings.kinematicsType == 1){
-        quadrilateralInverse(xTarget, yTarget, aChainLength, bChainLength);
+        _quadrilateralInverse(xTarget, yTarget, aChainLength, bChainLength);
     }
     else{
-        triangularInverse(xTarget, yTarget, aChainLength, bChainLength);
+        _triangularInverse(xTarget, yTarget, aChainLength, bChainLength);
     }
     
 }
 
-void  Kinematics::quadrilateralInverse(float xTarget,float yTarget, float* aChainLength, float* bChainLength){
+void  Kinematics::_quadrilateralInverse(float xTarget,float yTarget, float* aChainLength, float* bChainLength){
 
     //coordinate shift to put (0,0) in the center of the plywood from the left sprocket
     y = (halfHeight) + sysSettings.motorOffsetY  - yTarget;
@@ -189,7 +189,7 @@ void  Kinematics::quadrilateralInverse(float xTarget,float yTarget, float* aChai
 
 }
 
-void  Kinematics::triangularInverse(float xTarget,float yTarget, float* aChainLength, float* bChainLength){
+void  Kinematics::_triangularInverse(float xTarget,float yTarget, float* aChainLength, float* bChainLength){
     /*
     
     The inverse kinematics (relating an xy coordinate pair to the required chain lengths to hit that point)

--- a/cnc_ctrl_v1/Kinematics.cpp
+++ b/cnc_ctrl_v1/Kinematics.cpp
@@ -249,7 +249,7 @@ void  Kinematics::_triangularInverse(float xTarget,float yTarget, float* aChainL
     float Chain1Straight = sqrt(pow(Motor1Distance,2)-pow(R,2));
     float Chain2Straight = sqrt(pow(Motor2Distance,2)-pow(R,2));
 
-    //Calculate total weight held by both sprockets
+    //Calculate total weight held by both sprockets (but only half of chains weight?) Check with Joshua...
     float totalWeight=sledWeight+0.5*chainDensity*(Chain1Straight+Chain2Straight); // Newtons
 
     //    TensionDenominator= d(x_l       y_r-      x_r       y_l-      x_l      y_t     +x_t    y_l      +x_r       y_t    -x_t     y_r)

--- a/cnc_ctrl_v1/Kinematics.cpp
+++ b/cnc_ctrl_v1/Kinematics.cpp
@@ -69,6 +69,9 @@ void  Kinematics::inverse(float xTarget,float yTarget, float* aChainLength, floa
     
     */
     
+    //Confirm that the coordinates are on the wood
+    _verifyValidTarget(&xTarget, &yTarget);
+    
     if(sysSettings.kinematicsType == 1){
         quadrilateralInverse(xTarget, yTarget, aChainLength, bChainLength);
     }
@@ -79,9 +82,6 @@ void  Kinematics::inverse(float xTarget,float yTarget, float* aChainLength, floa
 }
 
 void  Kinematics::quadrilateralInverse(float xTarget,float yTarget, float* aChainLength, float* bChainLength){
-
-    //Confirm that the coordinates are on the wood
-    _verifyValidTarget(&xTarget, &yTarget);
 
     //coordinate shift to put (0,0) in the center of the plywood from the left sprocket
     y = (halfHeight) + sysSettings.motorOffsetY  - yTarget;
@@ -197,9 +197,6 @@ void  Kinematics::triangularInverse(float xTarget,float yTarget, float* aChainLe
     meeting at a point.
     
     */
-    
-    //Confirm that the coordinates are on the wood
-    _verifyValidTarget(&xTarget, &yTarget);
 
     //Set up variables
     float Chain1Angle = 0;

--- a/cnc_ctrl_v1/Kinematics.cpp
+++ b/cnc_ctrl_v1/Kinematics.cpp
@@ -203,18 +203,29 @@ void  Kinematics::_triangularInverse(float xTarget,float yTarget, float* aChainL
     float Chain2Angle = 0;
     float Chain1AroundSprocket = 0;
     float Chain2AroundSprocket = 0;
+    float xTangent1 = 0;
+    float yTangent1 = 0;
+    float xTangent2 = 0;
+    float yTangent2 = 0;
 
     //Calculate motor axes length to the bit
-    float Motor1Distance = sqrt(pow((-1*_xCordOfMotor - xTarget),2)+pow((_yCordOfMotor - yTarget),2));
+    float Motor1Distance = sqrt(pow((-1.0*_xCordOfMotor - xTarget),2)+pow((_yCordOfMotor - yTarget),2));
     float Motor2Distance = sqrt(pow((_xCordOfMotor - xTarget),2)+pow((_yCordOfMotor - yTarget),2));
 
     //Calculate the chain angles from horizontal, based on if the chain connects to the sled from the top or bottom of the sprocket
+    //Calculate the sprockets tangent contact points location
     if(sysSettings.chainOverSprocket == 1){
         Chain1Angle = asin((_yCordOfMotor - yTarget)/Motor1Distance) + asin(R/Motor1Distance);
         Chain2Angle = asin((_yCordOfMotor - yTarget)/Motor2Distance) + asin(R/Motor2Distance);
 
         Chain1AroundSprocket = R * Chain1Angle;
         Chain2AroundSprocket = R * Chain2Angle;
+        
+        xTangent1=-1.0*_xCordOfMotor+R*sin(Chain1Angle);
+        yTangent1=_yCordOfMotor+R*cos(Chain1Angle);
+
+        xTangent2=_xCordOfMotor-R*sin(Chain2Angle);
+        yTangent2=_yCordOfMotor+R*cos(Chain2Angle);
     }
     else{
         Chain1Angle = asin((_yCordOfMotor - yTarget)/Motor1Distance) - asin(R/Motor1Distance);
@@ -222,19 +233,43 @@ void  Kinematics::_triangularInverse(float xTarget,float yTarget, float* aChainL
 
         Chain1AroundSprocket = R * (3.14159 - Chain1Angle);
         Chain2AroundSprocket = R * (3.14159 - Chain2Angle);
-    }
+        
+        xTangent1=-1.0*_xCordOfMotor-R*sin(Chain1Angle);
+        yTangent1=_yCordOfMotor-R*cos(Chain1Angle);
 
+        xTangent2=_xCordOfMotor+R*sin(Chain2Angle);
+        yTangent2=_yCordOfMotor-R*cos(Chain2Angle);
+    }
+    // introducing chain density, sled weight, chain stretch (AKA elasticity or elongation factor)
+    float sledWeight = sysSettings.sledWeight; //Newtons
+    float chainDensity = 0.14*9.8/1000; // N/mm
+    float chainElasticity = sysSettings.chainElongationFactor; // mm/mm/Newton typically between 5x10E-6 and 8 x10E-6
+    
     //Calculate the straight chain length from the sprocket to the bit
     float Chain1Straight = sqrt(pow(Motor1Distance,2)-pow(R,2));
     float Chain2Straight = sqrt(pow(Motor2Distance,2)-pow(R,2));
+
+    //Calculate total weight held by both sprockets
+    float totalWeight=sledWeight+0.5*chainDensity*(Chain1Straight+Chain2Straight); // Newtons
+
+    //    TensionDenominator= d(x_l       y_r-      x_r       y_l-      x_l      y_t     +x_t    y_l      +x_r       y_t    -x_t     y_r)
+    float TensionDenominator= (xTangent1*yTangent2-xTangent2*yTangent1-xTangent1*yTarget+xTarget*yTangent1+xTangent2*yTarget-xTarget*yTangent2);
+    
+    //      T_l     = -(w         *sqrt(pow(x_l      -x_t    ,2.0)+pow(y_l      -y_t    ,2.0)) (x_r      -x_t))    /TensionDenominator
+    float Tension1 = - (totalWeight*sqrt(pow(xTangent1-xTarget,2.0)+pow(yTangent1-yTarget,2.0))*(xTangent2-xTarget))/TensionDenominator;
+
+    //     T_r     = (w         *sqrt(pow(x_r      -x_t    ,2.0)+pow(y_r      -y_t    ,2.0)) (x_l      -x_t))/(x_ly_r-x_ry_l-x_ly_t+x_ty_l+x_ry_t-x_ty_r)
+    float Tension2 = (totalWeight*sqrt(pow(xTangent2-xTarget,2.0)+pow(yTangent2-yTarget,2.0))*(xTangent1-xTarget))/TensionDenominator;
+    
+    // float HorizontalTension=Tension1*(xTarget-xTangent1)/Chain1Straight; // ready for future catenary equation computation
 
     //Correct the straight chain lengths to account for chain sag
     Chain1Straight *= (1 + ((sysSettings.chainSagCorrection / 1000000000000) * pow(cos(Chain1Angle),2) * pow(Chain1Straight,2) * pow((tan(Chain2Angle) * cos(Chain1Angle)) + sin(Chain1Angle),2)));
     Chain2Straight *= (1 + ((sysSettings.chainSagCorrection / 1000000000000) * pow(cos(Chain2Angle),2) * pow(Chain2Straight,2) * pow((tan(Chain1Angle) * cos(Chain2Angle)) + sin(Chain2Angle),2)));
 
-    //Calculate total chain lengths accounting for sprocket geometry and chain sag
-    float Chain1 = Chain1AroundSprocket + Chain1Straight / (1.0f + sysSettings.leftChainTolerance / 100.0f);
-    float Chain2 = Chain2AroundSprocket + Chain2Straight / (1.0f + sysSettings.rightChainTolerance / 100.0f);
+    //Calculate total chain lengths accounting for sprocket geometry, chain sag, chain tolerance, and chain elasticity
+    float Chain1 = Chain1AroundSprocket + Chain1Straight / ((1.0f + sysSettings.leftChainTolerance / 100.0f)*(1.0f+Tension1*chainElasticity));
+    float Chain2 = Chain2AroundSprocket + Chain2Straight / ((1.0f + sysSettings.rightChainTolerance / 100.0f)*(1.0f+Tension2*chainElasticity));
 
     //Subtract of the virtual length which is added to the chain by the rotation mechanism
     Chain1 = Chain1 - sysSettings.rotationDiskRadius;

--- a/cnc_ctrl_v1/Kinematics.h
+++ b/cnc_ctrl_v1/Kinematics.h
@@ -31,8 +31,6 @@
             Kinematics();
             void init  ();
             void  inverse   (float xTarget,float yTarget, float* aChainLength, float* bChainLength);
-            void  quadrilateralInverse   (float xTarget,float yTarget, float* aChainLength, float* bChainLength);
-            void  triangularInverse   (float xTarget,float yTarget, float* aChainLength, float* bChainLength);
             void  recomputeGeometry();
             void  forward(const float& chainALength, const float& chainBLength, float* xPos, float* yPos, float xGuess, float yGuess);
             //geometry
@@ -42,13 +40,15 @@
             float halfWidth;                      //Half the machine width
             float halfHeight;                    //Half the machine height
         private:
+            void  _quadrilateralInverse   (float xTarget,float yTarget, float* aChainLength, float* bChainLength);
+            void  _triangularInverse   (float xTarget,float yTarget, float* aChainLength, float* bChainLength);
+            void  _verifyValidTarget(float* xTarget,float* yTarget);
+            // quadrilateral specific
             float _moment(const float& Y1Plus, const float& Y2Plus, const float& MSinPhi, const float& MSinPsi1, const float& MCosPsi1, const float& MSinPsi2, const float& MCosPsi2);
             float _YOffsetEqn(const float& YPlus, const float& Denominator, const float& Psi);
             void  _MatSolv();
             void  _MyTrig();
-            void _verifyValidTarget(float* xTarget,float* yTarget);
-            //target router bit coordinates.
-            float x = 0;
+            float x = 0; //target router bit coordinates.
             float y = 0;
             float _xCordOfMotor;
             float _yCordOfMotor;

--- a/cnc_ctrl_v1/Report.cpp
+++ b/cnc_ctrl_v1/Report.cpp
@@ -182,7 +182,11 @@ void reportMaslowSettings() {
     Serial.print(F("$40=")); Serial.println(sysSettings.leftChainTolerance, 8);
     Serial.print(F("$41=")); Serial.println(sysSettings.rightChainTolerance, 8);
     Serial.print(F("$42=")); Serial.println(sysSettings.positionErrorLimit, 8);
-    
+    Serial.print(F("$43=")); Serial.println(sysSettings.reserved1, 8);
+    Serial.print(F("$44=")); Serial.println(sysSettings.reserved2, 8);
+    Serial.print(F("$45=")); Serial.println(sysSettings.chainElongationFactor, 8);
+    Serial.print(F("$46=")); Serial.println(sysSettings.sledWeight, 8);
+        
   #else
     Serial.print(F("$0=")); Serial.print(sysSettings.machineWidth);
     Serial.print(F(" (machine width, mm)\r\n$1=")); Serial.print(sysSettings.machineHeight, 8);
@@ -226,7 +230,11 @@ void reportMaslowSettings() {
     Serial.print(F(" (PWM frequency value 1=39,000Hz, 2=4,100Hz, 3=490Hz)\r\n$40=")); Serial.print(sysSettings.leftChainTolerance, 8);
     Serial.print(F(" (chain tolerance, left chain, mm)\r\n$41=")); Serial.print(sysSettings.rightChainTolerance, 8);
     Serial.print(F(" (chain tolerance, right chain, mm)\r\n$42=")); Serial.print(sysSettings.positionErrorLimit, 8);
-    Serial.print(F(" (position error alarm limit, mm)"));
+    Serial.print(F(" (position error alarm limit, mm)\r\n$43="));  Serial.print(sysSettings.reserved1,8);
+    Serial.print(F(" (reserved1, deg)\r\n$44="));Serial.print(sysSettings.reserved2,8);
+    Serial.print(F(" (reserved2, mm)\r\n$45=")); Serial.print(sysSettings.chainElongationFactor,8);
+    Serial.print(F(" (chain stretch factor, m/m/N)\r\n$46=")); Serial.print(sysSettings.sledWeight,8);
+    Serial.print(F(" (Sled Weight, N)\r\n"));
     Serial.println();
   #endif
 }

--- a/cnc_ctrl_v1/Settings.cpp
+++ b/cnc_ctrl_v1/Settings.cpp
@@ -108,7 +108,7 @@ void settingsReset() {
     sysSettings.reserved1 = 0.0;
     sysSettings.reserved2 = 0.0;
     sysSettings.chainElongationFactor = 8.1E-6; // m/m/N
-    sysSettings.sledWeight = 11.6*9.8; // Newtons. My sled has one ring kit, one Rigid 2200 router and two 2.35kg bricks on a 5/8" thick mdf 18" diameter base.
+    sysSettings.sledWeight = 11.6*9.8; // Newtons. For a sled with one ring kit, one Rigid 2200 router and two 2.35kg bricks on a 5/8" thick mdf 18" diameter base.
     sysSettings.eepromValidData = EEPROMVALIDDATA; // byte eepromValidData;
 }
 

--- a/cnc_ctrl_v1/Settings.cpp
+++ b/cnc_ctrl_v1/Settings.cpp
@@ -105,6 +105,10 @@ void settingsReset() {
     sysSettings.leftChainTolerance = 0.0;    // float leftChainTolerance;
     sysSettings.rightChainTolerance = 0.0;    // float rightChainTolerance;
     sysSettings.positionErrorLimit = 2.0;  // float positionErrorLimit;
+    sysSettings.reserved1 = 0.0;
+    sysSettings.reserved2 = 0.0;
+    sysSettings.chainElongationFactor = 8.1E-6; // m/m/N
+    sysSettings.sledWeight = 11.6*9.8; // Newtons. My sled has one ring kit, one Rigid 2200 router and two 2.35kg bricks on a 5/8" thick mdf 18" diameter base.
     sysSettings.eepromValidData = EEPROMVALIDDATA; // byte eepromValidData;
 }
 
@@ -405,6 +409,22 @@ byte settingsStoreGlobalSetting(const byte& parameter,const float& value){
               break;
         case 42:
               sysSettings.positionErrorLimit = value;
+              break;
+        case 43:
+              sysSettings.reserved1 = value;
+              kinematics.recomputeGeometry();
+              break;
+        case 44:
+              sysSettings.reserved2 = value;
+              kinematics.recomputeGeometry();
+              break;
+        case 45:
+              sysSettings.chainElongationFactor = value;
+              kinematics.recomputeGeometry();
+              break;
+        case 46:
+              sysSettings.sledWeight = value;
+              kinematics.recomputeGeometry();
               break;
         default:
               return(STATUS_INVALID_STATEMENT);

--- a/cnc_ctrl_v1/Settings.h
+++ b/cnc_ctrl_v1/Settings.h
@@ -20,7 +20,7 @@ Copyright 2014-2017 Bar Smith*/
 #ifndef settings_h
 #define settings_h
 
-#define SETTINGSVERSION 5      // The current version of settings, if this doesn't
+#define SETTINGSVERSION 6      // The current version of settings, if this doesn't
                                // match what is in EEPROM then settings on
                                // machine are reset to defaults
 #define EEPROMVALIDDATA 56     // This is just a random byte value that is used 
@@ -81,7 +81,10 @@ typedef struct {  // I think this is about ~128 bytes in size if I counted corre
   float leftChainTolerance;
   float rightChainTolerance;
   float positionErrorLimit;
-  byte eepromValidData;  // This should always be last, that way if an error
+  float reserved1;
+  float reserved2;
+  float chainElongationFactor; // m/m/N. This is the ratio of chain length increase due to chain tension. typically 8x10E-6; // m/m/N
+  float sledWeight; // Newtons. simply multiply kg by 9.8 or pounds by 2.2*9.8  byte eepromValidData;  // This should always be last, that way if an error
                          // happens in writing, it will not be written and we
 } settings_t;            // will know to reset the settings
 extern settings_t sysSettings;

--- a/cnc_ctrl_v1/Settings.h
+++ b/cnc_ctrl_v1/Settings.h
@@ -84,7 +84,8 @@ typedef struct {  // I think this is about ~128 bytes in size if I counted corre
   float reserved1;
   float reserved2;
   float chainElongationFactor; // m/m/N. This is the ratio of chain length increase due to chain tension. typically 8x10E-6; // m/m/N
-  float sledWeight; // Newtons. simply multiply kg by 9.8 or pounds by 2.2*9.8  byte eepromValidData;  // This should always be last, that way if an error
+  float sledWeight; // Newtons. simply multiply kg by 9.8 or pounds by 2.2*9.8  
+  byte eepromValidData;  // This should always be last, that way if an error
                          // happens in writing, it will not be written and we
 } settings_t;            // will know to reset the settings
 extern settings_t sysSettings;


### PR DESCRIPTION
Following tests with the help of [beta testers on the forum](https://forums.maslowcnc.com/t/call-for-beta-testers-chain-stretch-compensation-improvement/8742), proposed improved firmware is ready for a pull request:
 + It implements chain tension and stretch calculations to improve chain length calculation.
 + It uses a default sled weight of [25 lbs](https://forums.maslowcnc.com/t/bricks-on-sled/7235) (11.6 kilo) that you can set with macro $46=value where value  =kilo * 9.8 or lbs * 2.2*9.8. That settings would be eventually added to GroundControl.

The community will also enjoy **improved standard** Maslow Calibration results because:
 + the chain stretch compensation reduces the motor distance estimation error
 + the sag correction factor is still in use with that firmware.

Although the Standard calibration results will be improved, you might want to keep your known values if you trust them to be better.

### Why that step?
What are the benefits of making this firmware improvement in such a step?
 + More constant vertical scale accross the workspace.  
 + Users of the triangular link should get better results out of the current GroundControl Calibration scheme.    
 + When Ground Control will be improved with sled weight setting parameter, it will be easy to set it specifically for their sled.
 + With that update, one can also start experimenting with chain tolerance optimisation using the [Holey triangular Calibration (instructions here)](https://forums.maslowcnc.com/t/holey-triangular-calibration/6240/176?u=c0depr1sm). That without installing another firmware: Just download in a separate folder the HoleyCalibration GroundControl, then you'll find there the gcode and python scripts. 
 + (EDIT) It gets users ready for getting a better GroundControl with sled weight setting and is in line with Holey Triangular Calibration's features roadmap.
