### PR TITLE
Fix to EEPROM write issue

### DIFF
--- a/cnc_ctrl_v1/Axis.cpp
+++ b/cnc_ctrl_v1/Axis.cpp
@@ -197,6 +197,7 @@ int    Axis::detach(){
 
 int    Axis::attach(){
      motorGearboxEncoder.motor.attach();
+     sys.writeStepsToEEPROM = true;
      return 1;
 }
 

--- a/cnc_ctrl_v1/GCode.cpp
+++ b/cnc_ctrl_v1/GCode.cpp
@@ -167,6 +167,10 @@ byte  executeBcodeLine(const String& gcodeLine){
 
         //clear the flag, re-enable position error limit
         sys.state = (sys.state & (!STATE_POS_ERR_IGNORE));
+      
+        //set flag to write current encoder steps to EEPROM
+        sys.writeStepsToEEPROM = true;
+      
         return STATUS_OK;
     }
 

--- a/cnc_ctrl_v1/Settings.cpp
+++ b/cnc_ctrl_v1/Settings.cpp
@@ -161,6 +161,7 @@ void settingsSaveStepstoEEprom(){
         EEPROMVALIDDATA
       };
       EEPROM.put(310, sysSteps);
+      sys.writeStepsToEEPROM = false;
     }
 }
 

--- a/cnc_ctrl_v1/System.cpp
+++ b/cnc_ctrl_v1/System.cpp
@@ -410,7 +410,7 @@ void systemSaveAxesPosition(){
     /*
     Save steps of axes to EEPROM if they are all detached
     */
-    if (!leftAxis.attached() && !rightAxis.attached() && !zAxis.attached()){
+    if (sys.writeStepsToEEPROM && !leftAxis.attached() && !rightAxis.attached() && !zAxis.attached()){
         settingsSaveStepstoEEprom();
     }
 }

--- a/cnc_ctrl_v1/System.h
+++ b/cnc_ctrl_v1/System.h
@@ -64,6 +64,7 @@ typedef struct {
   int   nextTool;             //Stores the value of the next tool number eg: T4 -> 4
   float inchesToMMConversion; //Used to track whether to convert from inches, can probably be done in a way that doesn't require RAM
   float feedrate;             //The feedrate of the machine in mm/min
+  bool writeStepsToEEPROM;    // Flag to determine when need to write encoder steps to EEPROM.. used in execSystemRealtime and axis.attach
   // THE FOLLOWING IS USED FOR IMPORTING SETTINGS FROM FIRMWARE v1.00 AND EARLIER 
   // It can be deleted at some point
   byte oldSettingsFlag;

--- a/cnc_ctrl_v1/cnc_ctrl_v1.ino
+++ b/cnc_ctrl_v1/cnc_ctrl_v1.ino
@@ -60,6 +60,7 @@ void setup(){
     if (TLE5206 == true) { Serial.print(F(" TLE5206 ")); }
     Serial.println(F(" Detected"));
     sys.inchesToMMConversion = 1;
+    sys.writeStepsToEEPROM = false;
     settingsLoadFromEEprom();
     setupAxes();
     settingsLoadStepsFromEEprom();


### PR DESCRIPTION
This adds a flag (writeStepsToEEPROM) to the sys structure that is raised whenever an axis is attached.  The systemSaveAxesPosition() function tests that this flag is true and that all axes are detached.  If so, it calls settingsSaveStepstoEEprom() and after the EEPROM is saved, it clears the flag.  Therefore, the only time steps should be saved to EEPROM is after an axis becomes attached and then when all axes become detached.  So that's should only happen 2 seconds of idle after a motor move.