### PR TITLE
Move directWrite outside the loop

### DIFF
--- a/cnc_ctrl_v1/Axis.cpp
+++ b/cnc_ctrl_v1/Axis.cpp
@@ -257,12 +257,14 @@ void   Axis::test(){
     double encoderPos = motorGearboxEncoder.encoder.read(); //record the position now
     
     //move the motor
+    motorGearboxEncoder.motor.directWrite(255);
     while (i < 1000){
-        motorGearboxEncoder.motor.directWrite(255);
         i++;
         maslowDelay(1);
         if (sys.stop){return;}
     }
+    //stop the motor
+    motorGearboxEncoder.motor.directWrite(0);
     
     //check to see if it moved
     if(encoderPos - motorGearboxEncoder.encoder.read() > 500){
@@ -278,12 +280,14 @@ void   Axis::test(){
     
     //move the motor in the other direction
     i = 0;
+    motorGearboxEncoder.motor.directWrite(-255);
     while (i < 1000){
-        motorGearboxEncoder.motor.directWrite(-255);
         i++;
         maslowDelay(1);
         if (sys.stop){return;}
     }
+    //stop the motor
+    motorGearboxEncoder.motor.directWrite(0);
     
     //check to see if it moved
     if(encoderPos - motorGearboxEncoder.encoder.read() < -500){
@@ -293,8 +297,6 @@ void   Axis::test(){
         Serial.println(F("Direction 2 - Fail"));
     }
     
-    //stop the motor
-    motorGearboxEncoder.motor.directWrite(0);
     Serial.print(F("<Idle,MPos:0,0,0,WPos:0.000,0.000,0.000>"));
 }
 


### PR DESCRIPTION
No need to repeat 1000 times the same actions, it seems sufficient to do the directWrite only once before the loop instead.