### PR TITLE
Avoid compiler warnings about aux3...aux9

### DIFF
--- a/cnc_ctrl_v1/Probe.cpp
+++ b/cnc_ctrl_v1/Probe.cpp
@@ -19,7 +19,7 @@ Copyright 2014-2017 Bar Smith*/
 
 #include "Maslow.h"
 
-// the variable probePin is assigned in configAuxLow() in System.cpp
+// the variable probePin is assigned in setupAxes() in System.cpp
 
 bool checkForProbeTouch(const int& probePin) {
   /*

--- a/cnc_ctrl_v1/Spindle.cpp
+++ b/cnc_ctrl_v1/Spindle.cpp
@@ -17,7 +17,7 @@
 #include "Maslow.h"
 #include "Settings.h"
 
-// the variables SpindlePowerControlPin and LaserPowerPin are assigned in configAuxLow() in System.cpp 
+// the variables SpindlePowerControlPin and LaserPowerPin are assigned in setupAxes() in System.cpp 
 
 // Globals for Spindle control, both poorly named
 Servo myservo;  // create servo object to control a servo

--- a/cnc_ctrl_v1/Spindle.cpp
+++ b/cnc_ctrl_v1/Spindle.cpp
@@ -17,7 +17,7 @@
 #include "Maslow.h"
 #include "Settings.h"
 
-// the variables SpindlePowerControlPin and LaserPowerPin are assigned in setupAxes() in System.cpp 
+// the variables SpindlePowerControlPin and LaserPowerPin are assigned in setupAxes() in System.cpp
 
 // Globals for Spindle control, both poorly named
 Servo myservo;  // create servo object to control a servo

--- a/cnc_ctrl_v1/System.cpp
+++ b/cnc_ctrl_v1/System.cpp
@@ -21,7 +21,7 @@ Copyright 2014-2017 Bar Smith*/
 
 bool TLE5206;
 
-// extern values using AUX pins defined in  configAuxLow() and configAuxHigh()
+// extern values using AUX pins defined in  setupAxes()
 int SpindlePowerControlPin;  // output for controlling spindle power
 int ProbePin;                // use this input for zeroing zAxis with G38.2 gcode
 int LaserPowerPin;           // Use this output to turn on and off a laser diode
@@ -260,18 +260,17 @@ void   setupAxes(){
     digitalWrite(LaserPowerPin, LOW);
 
     // implement the AUXx values that are 'used'. This accomplishes setting their values at runtime.
-    // Using a dummy action is a compiler work-around to avoid
+    // Using these variables in a test permits to avoid warnings like
     //  "warning: variable ‘xxxxx’ set but not used [-Wunused-but-set-variable]"
     //  for AUX pins defined but not connected
-    // dummy actions to avoid compiler warnings
-    if (aux3 > 0) pinMode(aux3,INPUT);	// defined auxX are inputs by default
+
+    // defined auxX are inputs by default
+    if (aux3 > 0) pinMode(aux3,INPUT);
     if (aux5 > 0) pinMode(aux5,INPUT);
     if (aux6 > 0) pinMode(aux6,INPUT);
-    if(pcbVersion >= 3){ // TLE5206
-        if (aux7 > 0) pinMode(aux7,INPUT);
-        if (aux8 > 0) pinMode(aux8,INPUT);
-        if (aux9 > 0) pinMode(aux9,INPUT);
-    }
+    if (aux7 > 0) pinMode(aux7,INPUT);
+    if (aux8 > 0) pinMode(aux8,INPUT);
+    if (aux9 > 0) pinMode(aux9,INPUT);
 }
 
 int getPCBVersion(){

--- a/cnc_ctrl_v1/System.cpp
+++ b/cnc_ctrl_v1/System.cpp
@@ -128,9 +128,9 @@ void   setupAxes(){
         aux5 = 0;        // warning! this is the serial TX line on the Mega2560
         aux6 = 1;        // warning! this is the serial RX line on the Mega2560
 
-        aux7 = -1;       // unused
-        aux8 = -1;       // unused
-        aux9 = -1;       // unused
+        aux7 = -1;       // unconnected
+        aux8 = -1;       // unconnected
+        aux9 = -1;       // unconnected
     }
     else if(pcbVersion == 1){
         //PCB v1.1 Detected
@@ -163,9 +163,9 @@ void   setupAxes(){
         aux5 = A7;
         aux6 = A6;
 
-        aux7 = -1;       // unused
-        aux8 = -1;       // unused
-        aux9 = -1;       // unused
+        aux7 = -1;       // unconnected
+        aux8 = -1;       // unconnected
+        aux9 = -1;       // unconnected
     }
     else if(pcbVersion == 2){
         //PCB v1.2 Detected
@@ -199,9 +199,9 @@ void   setupAxes(){
         aux5 = A7;
         aux6 = A6;
 
-        aux7 = -1;       // unused
-        aux8 = -1;       // unused
-        aux9 = -1;       // unused
+        aux7 = -1;       // unconnected
+        aux8 = -1;       // unconnected
+        aux9 = -1;       // unconnected
     }
     else { // (pcbVersion == 3) // TLE5206
         //TLE5206 PCB v1.3 Detected

--- a/cnc_ctrl_v1/System.cpp
+++ b/cnc_ctrl_v1/System.cpp
@@ -127,6 +127,10 @@ void   setupAxes(){
         aux4 = 14;
         aux5 = 0;        // warning! this is the serial TX line on the Mega2560
         aux6 = 1;        // warning! this is the serial RX line on the Mega2560
+
+        aux7 = -1;       // unused
+        aux8 = -1;       // unused
+        aux9 = -1;       // unused
     }
     else if(pcbVersion == 1){
         //PCB v1.1 Detected
@@ -158,6 +162,10 @@ void   setupAxes(){
         aux4 = 14;
         aux5 = A7;
         aux6 = A6;
+
+        aux7 = -1;       // unused
+        aux8 = -1;       // unused
+        aux9 = -1;       // unused
     }
     else if(pcbVersion == 2){
         //PCB v1.2 Detected
@@ -190,8 +198,12 @@ void   setupAxes(){
         aux4 = 14;
         aux5 = A7;
         aux6 = A6;
+
+        aux7 = -1;       // unused
+        aux8 = -1;       // unused
+        aux9 = -1;       // unused
     }
-    else if(pcbVersion == 3){ // TLE5206
+    else { // (pcbVersion == 3) // TLE5206
         //TLE5206 PCB v1.3 Detected
         //MP1 - Right Motor
         encoder1A = 20; // INPUT
@@ -224,17 +236,6 @@ void   setupAxes(){
         aux7 = 45;
         aux8 = 46;
         aux9 = 47;
-    }else{  // default values to keep compiler from complaining
-        //AUX pins
-        aux1 = -1;
-        aux2 = -1;
-        aux3 = -1;
-        aux4 = -1;
-        aux5 = -1;
-        aux6 = -1;
-        aux7 = -1;
-        aux8 = -1;
-        aux9 = -1;
     }
 
     if(sysSettings.chainOverSprocket == 1){
@@ -262,10 +263,11 @@ void   setupAxes(){
     // Using a dummy action is a compiler work-around to avoid
     //  "warning: variable ‘xxxxx’ set but not used [-Wunused-but-set-variable]"
     //  for AUX pins defined but not connected
-    if (aux3 > 0) pinMode(aux3,INPUT); // dummy actions to avoid compiler warnings
+    // dummy actions to avoid compiler warnings
+    if (aux3 > 0) pinMode(aux3,INPUT);	// defined auxX are inputs by default
     if (aux5 > 0) pinMode(aux5,INPUT);
     if (aux6 > 0) pinMode(aux6,INPUT);
-    if(pcbVersion == 3){ // TLE5206
+    if(pcbVersion >= 3){ // TLE5206 
         if (aux7 > 0) pinMode(aux7,INPUT);
         if (aux8 > 0) pinMode(aux8,INPUT);
         if (aux9 > 0) pinMode(aux9,INPUT);

--- a/cnc_ctrl_v1/System.cpp
+++ b/cnc_ctrl_v1/System.cpp
@@ -65,7 +65,7 @@ void   setupAxes(){
 
     */
 
-    
+
     int encoder1A;
     int encoder1B;
     int encoder2A;
@@ -251,7 +251,7 @@ void   setupAxes(){
     leftAxis.setPIDValues(&sysSettings.KpPos, &sysSettings.KiPos, &sysSettings.KdPos, &sysSettings.propWeightPos, &sysSettings.KpV, &sysSettings.KiV, &sysSettings.KdV, &sysSettings.propWeightV);
     rightAxis.setPIDValues(&sysSettings.KpPos, &sysSettings.KiPos, &sysSettings.KdPos, &sysSettings.propWeightPos, &sysSettings.KpV, &sysSettings.KiV, &sysSettings.KdV, &sysSettings.propWeightV);
     zAxis.setPIDValues(&sysSettings.zKpPos, &sysSettings.zKiPos, &sysSettings.zKdPos, &sysSettings.zPropWeightPos, &sysSettings.zKpV, &sysSettings.zKiV, &sysSettings.zKdV, &sysSettings.zPropWeightV);
-    
+
     // Assign AUX pins to extern variables used by functions like Spindle and Probe
     SpindlePowerControlPin = aux1;   // output for controlling spindle power
     LaserPowerPin = aux2;            // output for controlling a laser diode
@@ -267,7 +267,7 @@ void   setupAxes(){
     if (aux3 > 0) pinMode(aux3,INPUT);	// defined auxX are inputs by default
     if (aux5 > 0) pinMode(aux5,INPUT);
     if (aux6 > 0) pinMode(aux6,INPUT);
-    if(pcbVersion >= 3){ // TLE5206 
+    if(pcbVersion >= 3){ // TLE5206
         if (aux7 > 0) pinMode(aux7,INPUT);
         if (aux8 > 0) pinMode(aux8,INPUT);
         if (aux9 > 0) pinMode(aux9,INPUT);

--- a/cnc_ctrl_v1/System.cpp
+++ b/cnc_ctrl_v1/System.cpp
@@ -262,13 +262,13 @@ void   setupAxes(){
     // Using a dummy action is a compiler work-around to avoid
     //  "warning: variable ‘xxxxx’ set but not used [-Wunused-but-set-variable]"
     //  for AUX pins defined but not connected
-    if (aux3 > 0) pinMode(aux3,INPUT_PULLUP); // dummy action to avoid compiler warnings
-    if (aux5 > 0) pinMode(aux3,INPUT_PULLUP);
-    if (aux6 > 0) pinMode(aux3,INPUT_PULLUP);
+    if (aux3 > 0) pinMode(aux3,INPUT); // dummy actions to avoid compiler warnings
+    if (aux5 > 0) pinMode(aux5,INPUT);
+    if (aux6 > 0) pinMode(aux6,INPUT);
     if(pcbVersion == 3){ // TLE5206
-        if (aux7 > 0) pinMode(aux7,INPUT_PULLUP); // dummy action to avoid compiler warnings
-        if (aux8 > 0) pinMode(aux8,INPUT_PULLUP);
-        if (aux9 > 0) pinMode(aux9,INPUT_PULLUP);
+        if (aux7 > 0) pinMode(aux7,INPUT);
+        if (aux8 > 0) pinMode(aux8,INPUT);
+        if (aux9 > 0) pinMode(aux9,INPUT);
     }
 }
 

--- a/cnc_ctrl_v1/System.cpp
+++ b/cnc_ctrl_v1/System.cpp
@@ -224,6 +224,17 @@ void   setupAxes(){
         aux7 = 45;
         aux8 = 46;
         aux9 = 47;
+    }else{  // default values to keep compiler from complaining
+        //AUX pins
+        aux1 = -1;
+        aux2 = -1;
+        aux3 = -1;
+        aux4 = -1;
+        aux5 = -1;
+        aux6 = -1;
+        aux7 = -1;
+        aux8 = -1;
+        aux9 = -1;
     }
 
     if(sysSettings.chainOverSprocket == 1){
@@ -239,27 +250,26 @@ void   setupAxes(){
     leftAxis.setPIDValues(&sysSettings.KpPos, &sysSettings.KiPos, &sysSettings.KdPos, &sysSettings.propWeightPos, &sysSettings.KpV, &sysSettings.KiV, &sysSettings.KdV, &sysSettings.propWeightV);
     rightAxis.setPIDValues(&sysSettings.KpPos, &sysSettings.KiPos, &sysSettings.KdPos, &sysSettings.propWeightPos, &sysSettings.KpV, &sysSettings.KiV, &sysSettings.KdV, &sysSettings.propWeightV);
     zAxis.setPIDValues(&sysSettings.zKpPos, &sysSettings.zKiPos, &sysSettings.zKdPos, &sysSettings.zPropWeightPos, &sysSettings.zKpV, &sysSettings.zKiV, &sysSettings.zKdV, &sysSettings.zPropWeightV);
+    
+    // Assign AUX pins to extern variables used by functions like Spindle and Probe
+    SpindlePowerControlPin = aux1;   // output for controlling spindle power
+    LaserPowerPin = aux2;            // output for controlling a laser diode
+    ProbePin = aux4;                 // use this input for zeroing zAxis with G38.2 gcode
+    pinMode(LaserPowerPin, OUTPUT);
+    digitalWrite(LaserPowerPin, LOW);
 
     // implement the AUXx values that are 'used'. This accomplishes setting their values at runtime.
-    // Using a separate function is a compiler work-around to avoid
+    // Using a dummy action is a compiler work-around to avoid
     //  "warning: variable ‘xxxxx’ set but not used [-Wunused-but-set-variable]"
     //  for AUX pins defined but not connected
-    configAuxLow(aux1, aux2, aux3, aux4, aux5, aux6);
+    if (aux3 > 0) pinMode(aux3,INPUT_PULLUP); // dummy action to avoid compiler warnings
+    if (aux5 > 0) pinMode(aux3,INPUT_PULLUP);
+    if (aux6 > 0) pinMode(aux3,INPUT_PULLUP);
     if(pcbVersion == 3){ // TLE5206
-      configAuxHigh(aux7, aux8, aux9);
+        if (aux7 > 0) pinMode(aux7,INPUT_PULLUP); // dummy action to avoid compiler warnings
+        if (aux8 > 0) pinMode(aux8,INPUT_PULLUP);
+        if (aux9 > 0) pinMode(aux9,INPUT_PULLUP);
     }
-}
-
-// Assign AUX pins to extern variables used by functions like Spindle and Probe
-void configAuxLow(int aux1, int aux2, int aux3, int aux4, int aux5, int aux6) {
-  SpindlePowerControlPin = aux1;   // output for controlling spindle power
-  ProbePin = aux4;                 // use this input for zeroing zAxis with G38.2 gcode
-  LaserPowerPin = aux2;            // output for controlling a laser diode
-  pinMode(LaserPowerPin, OUTPUT);
-  digitalWrite(LaserPowerPin, LOW);
-}
-
-void configAuxHigh(int aux7, int aux8, int aux9) {
 }
 
 int getPCBVersion(){

--- a/cnc_ctrl_v1/System.h
+++ b/cnc_ctrl_v1/System.h
@@ -90,6 +90,4 @@ void systemSaveAxesPosition();
 void systemReset();
 byte systemExecuteCmdstring(String&);
 void setPWMPrescalers(int prescalerChoice);
-void configAuxLow(int A1, int A2, int A3, int A4, int A5, int A6);
-void configAuxHigh(int A7, int A8, int A9);
 #endif


### PR DESCRIPTION
Variables `aux3` ... `aux9` needed to be initialized and used, or the compiler emits warnings.

A negative value has been set initially, and dummy actions avoid the warning.
If in doubt, `INPUT_PULLUP` was used so that pins don't float and don't fire any interrupts for no reason.

This version doesn't use functions as workaround against the warnings, so assignations have been put back in `setupAxes()`, hopefully their intended place originally.