### PR TITLE
Avoid PWM value 255 for TLE5206

### DIFF
--- a/cnc_ctrl_v1/Motor.cpp
+++ b/cnc_ctrl_v1/Motor.cpp
@@ -144,6 +144,7 @@ void Motor::write(int speed, bool force){
             }
         } 
         else { // TLE5206
+            speed = constrain(speed, 0, 254); // avoid issue when PWM value is 255
             if (forward) {
                 if (speed > 0) {
                     if (usePin2) {


### PR DESCRIPTION
This patch only affects TLE5206 boards. If the PWM value is 255 it is changed to 254. This works around the  symptom noted in issue #500