### PR TITLE
Confine changes to Axis::test()

### DIFF
--- a/cnc_ctrl_v1/Axis.cpp
+++ b/cnc_ctrl_v1/Axis.cpp
@@ -278,6 +278,11 @@ void   Axis::test(){
     encoderPos = motorGearboxEncoder.encoder.read();
     Serial.print(F("<Idle,MPos:0,0,0,WPos:0.000,0.000,0.000>"));
     
+    if (TLE5206) {
+        // let the motor coast to a stop
+        maslowDelay(100);
+    }
+
     //move the motor in the other direction
     i = 0;
     motorGearboxEncoder.motor.directWrite(-255);

--- a/cnc_ctrl_v1/Motor.cpp
+++ b/cnc_ctrl_v1/Motor.cpp
@@ -49,7 +49,7 @@ int  Motor::setupMotor(const int& pwmPin, const int& pin1, const int& pin2){
     digitalWrite(_pin2,    LOW) ;
     digitalWrite(_pwmPin,  LOW);
   } else {
-    pinMode(_pwmPin,   INPUT);
+    pinMode(_pwmPin,   INPUT_PULLUP);
     pinMode(_pin1,     OUTPUT);
     pinMode(_pin2,     OUTPUT);
 


### PR DESCRIPTION
This patch only affects TLE5206 boards. This works around the symptom noted in issue #500, addressing it as a motor coasting issue. 

>The TLE5206 chip is asserting its open-collector Error Flag, which we connect to ENx but don't pay attention to. (_pwmPin in Motor.cpp, note to self - needs to be initialized INPUT_PULLUP).
When the movement commanded by Motor::write() is a start from a dead stop or while the motor is coasting and the direction abruptly changes, the TLE5206 can see the motor windings as a dead short and asserts EF.
