### PR TITLE
recognize a soft reset command in the serial stream

### DIFF
--- a/cnc_ctrl_v1/Config.h
+++ b/cnc_ctrl_v1/Config.h
@@ -61,4 +61,8 @@
                             // smooth.  This is only a minimum, and the actual
                             // timeout could be significantly larger.
 
+#define CMD_RESET 0x18      // ctrl-x., if received the program should do a soft reset
+                            // if received the program should do a soft reset
+#define CMD_RESET2 '`'      // alternate char because GC won't use control characters in a macro
+
 #endif

--- a/cnc_ctrl_v1/GCode.cpp
+++ b/cnc_ctrl_v1/GCode.cpp
@@ -44,7 +44,24 @@ void readSerialCommands(){
     if (Serial.available() > 0) {
         while (Serial.available() > 0) {
             char c = Serial.read();
-            if (c == '!'){
+            if ((c == CMD_RESET) || (c == CMD_RESET2)){      // immediate soft reset
+                // stop the motors and save the position
+                sys.stop = true;
+                quickCommandFlag = true;
+                bit_false(sys.pause, PAUSE_FLAG_USER_PAUSE);
+                sys.writeStepsToEEPROM = true;
+                // report the command 
+                Serial.println(F("\n\nsoft reset commanded\n\n"));
+                // mimic the firmware reset response sequence so GC thinks we've just reset
+                Serial.print(F("\nPCB v1."));
+                Serial.print(getPCBVersion());
+                if (TLE5206 == true) { Serial.print(F(" TLE5206 ")); }
+                Serial.println(F(" Detected"));
+                Serial.println(F("Grbl v1.00"));  
+                Serial.println(F("ready"));
+                reportStatusMessage(STATUS_OK);
+            }
+            else if (c == '!'){
                 sys.stop = true;
                 quickCommandFlag = true;
                 bit_false(sys.pause, PAUSE_FLAG_USER_PAUSE);


### PR DESCRIPTION
• Stop immediately
• Save the position
• Report the command received
• Mimic the firmware response sequence so GC thinks we've just reset.


 Teensy3.5/3.6 and GrandCentralMetroM4 don't reset when GC does the special Arduino serial-port-reset trick.
 This PR adds a one-character command to trigger a soft reset. GRBL and MaslowDue use ctrl-X, so we match that. GC doesn't allow control characters in macros, so we allow a second option.
Since we've already been through most of the important things in setup(), we only need to send the text that GC expects when making a connection.
 GroundControl PR#791 is the counterpart that sends the ctrl-X as part of the connection handshake.
