### PR TITLE
Adds directWrite(0) at end of B11

### DIFF
--- a/cnc_ctrl_v1/GCode.cpp
+++ b/cnc_ctrl_v1/GCode.cpp
@@ -285,6 +285,12 @@ byte  executeBcodeLine(const String& gcodeLine){
             execSystemRealtime();
             if (sys.stop){return STATUS_OK;}
         }
+        if (gcodeLine.indexOf('L') != -1){
+            leftAxis.motorGearboxEncoder.motor.directWrite(0);
+        }
+        else{
+            rightAxis.motorGearboxEncoder.motor.directWrite(0);
+        }
         bit_false(sys.state,STATE_POS_ERR_IGNORE);
         return STATUS_OK;
     }


### PR DESCRIPTION
Adds a directWrite(0) at end so motors are stopped.  They would stop on their own after the next move command is issued (typically where slack is reintroducted) but for some reason, currently unknown, the chain length measurement B10 function isn't working consistently and the motors keep getting pulled.  B11 could use further tweeking (no need to send directWrites every iteration of the timing loop).