### PR TITLE
Add TLE9201 board id6

### DIFF
--- a/cnc_ctrl_v1/Config.h
+++ b/cnc_ctrl_v1/Config.h
@@ -33,6 +33,11 @@
                            // simulator. Normally, you would not define this directly, but
                            // use PlatformIO to build the simavr environment.
 
+// #define alarmsTLE9201   // Uncomment this to make TLE9201 over-current/over-temp alarms active
+                           // Note that in normal operation these alarms are often triggered by 
+                           // abrupt direction change. Until acceleration control is available,
+                           // the alarms aren't useful.
+
 #define LOOPINTERVAL 10000 // What is the frequency of the PID loop in microseconds
 
 // Define version detect pins

--- a/cnc_ctrl_v1/Motor.cpp
+++ b/cnc_ctrl_v1/Motor.cpp
@@ -38,7 +38,26 @@ int  Motor::setupMotor(const int& pwmPin, const int& pin1, const int& pin2){
   _pin2  = pin2;
   _attachedState = 0;
 
-  if (TLE5206 == false) {
+  if (TLE5206 == true) {
+  //set pinmodes
+    pinMode(_pwmPin,   INPUT);   // TLE5206 'Error Flag' pin
+    pinMode(_pin1,     OUTPUT);
+    pinMode(_pin2,     OUTPUT);
+    
+ //stop the motor
+    digitalWrite(_pin1,    LOW);
+    digitalWrite(_pin2,    LOW) ;
+    
+  } else if (TLE9201 == true) {
+  //set pinmodes
+    pinMode(_pwmPin,   OUTPUT);
+    pinMode(_pin1,     OUTPUT);   // TLE9201 DIR pin
+    pinMode(_pin2,     OUTPUT);   // TLE9201 ENABLE pin
+    
+  //stop the motor
+    digitalWrite(_pin2,    HIGH); // TLE9201 ENABLE pin, LOW = on
+    
+  } else {
   //set pinmodes
     pinMode(_pwmPin,   OUTPUT);
     pinMode(_pin1,     OUTPUT);
@@ -48,14 +67,6 @@ int  Motor::setupMotor(const int& pwmPin, const int& pin1, const int& pin2){
     digitalWrite(_pin1,    HIGH);
     digitalWrite(_pin2,    LOW) ;
     digitalWrite(_pwmPin,  LOW);
-  } else {
-    pinMode(_pwmPin,   INPUT);
-    pinMode(_pin1,     OUTPUT);
-    pinMode(_pin2,     OUTPUT);
-
-    //stop the motor
-    digitalWrite(_pin1,    LOW);
-    digitalWrite(_pin2,    LOW) ;
   }
   return 1;
 }
@@ -66,16 +77,20 @@ void Motor::attach(){
 
 void Motor::detach(){
     if (_attachedState != 0) {
-      if (TLE5206 == false) {
+        if (TLE5206 == true) {
+          //stop the motor
+          digitalWrite(_pin1,    LOW);
+          digitalWrite(_pin2,    LOW) ;
+        } else if (TLE9201 == true) {
         //stop the motor
-        digitalWrite(_pin1,    HIGH);
-        digitalWrite(_pin2,    LOW) ;
-        digitalWrite(_pwmPin,  LOW);
-      } else {
-        //stop the motor
-        digitalWrite(_pin1,    LOW);
-        digitalWrite(_pin2,    LOW) ;
-      }
+          digitalWrite(_pin2,    HIGH); // TLE9201 ENABLE pin, LOW = on
+          analogWrite(_pwmPin,   0);
+        } else {
+          //stop the motor
+          digitalWrite(_pin1,    HIGH);
+          digitalWrite(_pin2,    LOW) ;
+          digitalWrite(_pwmPin,  LOW);
+        }
     }
     _attachedState = 0;
 }
@@ -107,7 +122,7 @@ void Motor::write(int speed, bool force){
         bool usePin1 = ((_pin1 != 4) && (_pin1 != 13) && (_pin1 != 11) && (_pin1 != 12)); // avoid PWM using timer0 or timer1
         bool usePin2 = ((_pin2 != 4) && (_pin2 != 13) && (_pin2 != 11) && (_pin2 != 12)); // avoid PWM using timer0 or timer1
         bool usepwmPin = ((TLE5206 == false) && (_pwmPin != 4) && (_pwmPin != 13) && (_pwmPin != 11) && (_pwmPin != 12)); // avoid PWM using timer0 or timer1       
-        if (!TLE5206) {
+        if (!(TLE5206 || TLE9201)) { // L298 boards
             if (forward){
                 if (usepwmPin){
                     digitalWrite(_pin1 , HIGH );
@@ -143,7 +158,7 @@ void Motor::write(int speed, bool force){
                 }
             }
         } 
-        else { // TLE5206
+        else if (TLE5206)  {
             speed = constrain(speed, 0, 254); // avoid issue when PWM value is 255
             if (forward) {
                 if (speed > 0) {
@@ -171,6 +186,50 @@ void Motor::write(int speed, bool force){
                 }
             }
         }
+        else if (TLE9201) {
+            int dirPin     = _pin1;
+            int enablePin  = _pin2;
+            const int TOP  = 1;
+            /*
+            * The TLE9201 uses dedicated DIR, PWM and DISable pins,
+            * so logic from previous chips won't work. In addition, 
+            * the left and right motors are affected by chainOverSprocket 
+            * but the Z motor is not.
+            */
+
+            uint8_t dirCMD;
+            uint8_t extend = HIGH;
+            uint8_t retract = LOW;
+            if (_pwmPin == ENB) { // Z motor unaffected by chainOverSprocket
+                if (forward) {
+                    dirCMD = retract;
+                } 
+                else {
+                    dirCMD = extend;
+                } 
+            } else { // L and R motor affected by chainOverSprocket
+                if(sysSettings.chainOverSprocket == TOP) {
+                    if (forward) {
+                        dirCMD = extend;
+                    } 
+                    else {
+                        dirCMD = retract;
+                    } 
+                } else {
+                    if (forward) {
+                        dirCMD = retract;
+                    } 
+                    else {
+                        dirCMD = extend;
+                    }
+                }
+            }
+
+            digitalWrite(dirPin, dirCMD); // TLE9201 DIR pin
+            analogWrite (_pwmPin, speed); // TLE9201 PWM pin
+            digitalWrite(enablePin, LOW); // TLE9201 ENABLE pin, HIGH = disable
+        }
+    else {} // add new boards here
     }
 }
 

--- a/cnc_ctrl_v1/Motor.h
+++ b/cnc_ctrl_v1/Motor.h
@@ -50,4 +50,8 @@
             
     };
     extern bool TLE5206;
+    extern bool TLE9201;
+    extern int ENA;
+    extern int ENB;
+    extern int ENC;
     #endif

--- a/cnc_ctrl_v1/Report.cpp
+++ b/cnc_ctrl_v1/Report.cpp
@@ -259,6 +259,17 @@ void  returnError(){
         Serial.println(F("]"));
         if (!sys.stop) {
           if (!(sys.state & STATE_POS_ERR_IGNORE)) {
+            #ifdef alarmsTLE9201
+                if ((digitalRead(SO1) == HIGH) && (digitalRead(ENA) == LOW)) {
+                    reportAlarmMessage(ALARM_MOTOR1_CURRENT_TEMPERATURE_ERROR);
+                }
+                if ((digitalRead(SO2) == HIGH) && (digitalRead(ENB) == LOW)) {
+                    reportAlarmMessage(ALARM_MOTOR2_CURRENT_TEMPERATURE_ERROR);
+                }
+                if ((digitalRead(SO3) == HIGH) && (digitalRead(ENC) == LOW)) {
+                    reportAlarmMessage(ALARM_MOTOR3_CURRENT_TEMPERATURE_ERROR);
+                }
+            #endif
             if ((abs(leftAxis.error()) >= sysSettings.positionErrorLimit) || (abs(rightAxis.error()) >= sysSettings.positionErrorLimit)) {
                 reportAlarmMessage(ALARM_POSITION_LIMIT_ERROR);
             }

--- a/cnc_ctrl_v1/System.h
+++ b/cnc_ctrl_v1/System.h
@@ -79,6 +79,12 @@ extern byte systemRtExecAlarm;
 extern int SpindlePowerControlPin;
 extern int LaserPowerPin;
 extern int ProbePin;
+extern int SO1;
+extern int SO2;
+extern int SO3;
+extern int ENA;
+extern int ENB;
+extern int ENC;
 
 void  calibrateChainLengths(String);
 void  setupAxes();

--- a/cnc_ctrl_v1/cnc_ctrl_v1.ino
+++ b/cnc_ctrl_v1/cnc_ctrl_v1.ino
@@ -31,6 +31,7 @@
  */
     
 
+// TLE9201 version
 // TLE5206 version
 
 #include "Maslow.h"
@@ -58,6 +59,7 @@ void setup(){
     Serial.print(F("PCB v1."));
     Serial.print(getPCBVersion());
     if (TLE5206 == true) { Serial.print(F(" TLE5206 ")); }
+    if (TLE9201 == true) { Serial.print(F(" TLE9201 ")); }
     Serial.println(F(" Detected"));
     sys.inchesToMMConversion = 1;
     sys.writeStepsToEEPROM = false;


### PR DESCRIPTION
The TLE5206 is being sunsetted, and the replacement is the TLE9201. That chip has yet a different control arrangement - simpler but different enough that it needs separate handling. It has one dedicated PWM input, one dedicated DIRection input, and one ENAble input. PWM, DIR, ENA is a more common control scheme for motor drivers, so it's possible that future boards that drive separate motor driver boards would be able to use this configuration. The TLE9201 is rated for 6A continuous and runs in chopper mode at currents above that. It can handle PWM up to 20kHz (much better than the 1kHz of the TLE5206). It tri-states the outputs if it senses over-temperature, and flags the error.

The board uses gpio pins from the Mega XIO connector to increase the number of AUX pins to 9, three of which have hardware PWM (PWM for spindle speed would be possible) and two of which can do analog input as well as digital IO. It also frees up the SPI pins though it doesn't use them - the Mega seems busy enough already. Finally, it has an on-board EEPROM, buffers on the encoder lines and automatic voltage selection so it is hardware compatible with the MaslowDue project. (It runs a branch of that code on a Due, but needs someone with more PID-fu than I possess to tune the loop make it purr instead of growl. I'll send a board to someone serious about working on that. ;) DM me.)

