### PR TITLE
Resolve comile warning in function maslow ring buffer  increment end()

### DIFF
--- a/cnc_ctrl_v1/maslowRingBuffer.cpp
+++ b/cnc_ctrl_v1/maslowRingBuffer.cpp
@@ -169,7 +169,7 @@ int maslowRingBuffer::_incrementEnd(){
         }
     else
         _endOfString = (_endOfString+1) % INCBUFFERLENGTH;
-        return 0;
+    return 0;
  }
 
 void maslowRingBuffer::_incrementVariable(int* variable){


### PR DESCRIPTION
The compiler posts a warning:

sketch/maslowRingBuffer.cpp: In member function 'int maslowRingBuffer::_incrementEnd()':
sketch/maslowRingBuffer.cpp:170:5: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
else
^~~~
sketch/maslowRingBuffer.cpp:172:9: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the 'else'
return 0;
^~~~~~

Make the recommended change.