### PR TITLE
Initialize sys.feedrate to 400 mm/min

### DIFF
--- a/cnc_ctrl_v1/cnc_ctrl_v1.ino
+++ b/cnc_ctrl_v1/cnc_ctrl_v1.ino
@@ -63,8 +63,8 @@ void setup(){
     Serial.println(F(" Detected"));
     sys.inchesToMMConversion = 1;
     sys.writeStepsToEEPROM = false;
-    sys.feedrate = 400;
     settingsLoadFromEEprom();
+    sys.feedrate = sysSettings.maxFeed / 2.0;
     setupAxes();
     settingsLoadStepsFromEEprom();
     // Set initial desired position of the machine to its current position

--- a/cnc_ctrl_v1/cnc_ctrl_v1.ino
+++ b/cnc_ctrl_v1/cnc_ctrl_v1.ino
@@ -63,6 +63,7 @@ void setup(){
     Serial.println(F(" Detected"));
     sys.inchesToMMConversion = 1;
     sys.writeStepsToEEPROM = false;
+    sys.feedrate = 400;
     settingsLoadFromEEprom();
     setupAxes();
     settingsLoadStepsFromEEprom();


### PR DESCRIPTION
sys.feedrate was not being initialized and resulted in a feed rate of 1 mm/min when gcode was sent without a feed rate (if no other feed rate had been previously sent).  This sets the feedrate to 400 mm/min (half of the maximum feed rate).  It appears to me that the firmware works in metric so this should be appropriate .