### PR TITLE
EEPROM write after B06 and B08 Commands

### DIFF
--- a/cnc_ctrl_v1/GCode.cpp
+++ b/cnc_ctrl_v1/GCode.cpp
@@ -206,6 +206,7 @@ byte  executeBcodeLine(const String& gcodeLine){
         Serial.print(rightAxis.read());
         Serial.println(F("mm"));
       
+        kinematics.forward(leftAxis.read(), rightAxis.read(), &sys.xPosition, &sys.yPosition, 0, 0);
         //set flag to write current encoder steps to EEPROM
         sys.writeStepsToEEPROM = true;
 

--- a/cnc_ctrl_v1/GCode.cpp
+++ b/cnc_ctrl_v1/GCode.cpp
@@ -205,6 +205,9 @@ byte  executeBcodeLine(const String& gcodeLine){
         Serial.print(F("Right: "));
         Serial.print(rightAxis.read());
         Serial.println(F("mm"));
+      
+        //set flag to write current encoder steps to EEPROM
+        sys.writeStepsToEEPROM = true;
 
         return STATUS_OK;
     }
@@ -225,6 +228,9 @@ byte  executeBcodeLine(const String& gcodeLine){
 
         Serial.println(F("Message: The machine chains have been manually re-calibrated."));
 
+        //set flag to write current encoder steps to EEPROM
+        sys.writeStepsToEEPROM = true;
+      
         return STATUS_OK;
     }
 


### PR DESCRIPTION
The firmware does not currently write steps to EEPROM after the completion of a B06 or B08 command, both of write directly modify the steps value of the encoder.  Normally this isn't a problem since steps get written after a move occurs, but during software testing I discovered I had to continuously reset my chain lengths every time I restarted webcontrol because the were set to 0,0 in EEPROM.  This fix sets sys.writeStepsToEEPROM to true after those commands are issued so the new steps value will be written to EEPROM.