### PR TITLE
add B99 command to control FAKE_SERVO mode

### DIFF
--- a/cnc_ctrl_v1/Axis.cpp
+++ b/cnc_ctrl_v1/Axis.cpp
@@ -17,6 +17,7 @@
 
 
 #include "Maslow.h"
+// #include <EEPROM.h>
 
 void Axis::setup(const int& pwmPin, const int& directionPin1, const int& directionPin2, const int& encoderPin1, const int& encoderPin2, const char& axisName, const unsigned long& loopInterval)
 {
@@ -84,14 +85,14 @@ void   Axis::setSteps(const long& steps){
 
 void   Axis::computePID(){
     
-    #ifdef FAKE_SERVO
-      if (motorGearboxEncoder.motor.attached()){
-        // Adds up to 10% error just to simulate servo noise
-        double rpm = (-1 * _pidOutput) * random(90, 110) / 100;
-        unsigned long steps = motorGearboxEncoder.encoder.read() + round( rpm * *_encoderSteps * LOOPINTERVAL)/(60 * 1000000);
-        motorGearboxEncoder.encoder.write(steps);
+      if (FAKE_SERVO_STATE != 0) {
+          if (motorGearboxEncoder.motor.attached()){
+            // Adds up to 10% error just to simulate servo noise
+            double rpm = (-1 * _pidOutput) * random(90, 110) / 100;
+            unsigned long steps = motorGearboxEncoder.encoder.read() + round( rpm * *_encoderSteps * LOOPINTERVAL)/(60 * 1000000);
+            motorGearboxEncoder.encoder.write(steps);
+          }
       }
-    #endif
 
     if (_disableAxisForTesting || !motorGearboxEncoder.motor.attached()){
         return;

--- a/cnc_ctrl_v1/Config.h
+++ b/cnc_ctrl_v1/Config.h
@@ -25,9 +25,12 @@
                            // LOOPINTERVAL tuning
 #define KINEMATICSDBG 0    // set to 1 for additional kinematics debug messaging
 
-// #define FAKE_SERVO      // Uncomment this line to cause the Firmware to mimic
-                           // a servo updating the encoder steps even if no servo
-                           // is connected.  Useful for testing on an arduino only
+#define FAKE_SERVO 4095    // store the state of FAKE_SERVO in EEPROM[ 4095 ] to preserve
+                           // the state of FAKE_SERVO mode over resets.
+                           // Use 'B99 ON' to turn FAKE_SERVO mode on and set EEPROM[ 4095 ] to '1',
+                           // 'B99' with no parameter, or any parameter other than 'ON' 
+                           // puts a '0' in that location and turns FAKE_SERVO mode off.
+                           // Useful for testing on an arduino only (e.g. without motors).
 
 // #define SIMAVR          // Uncomment this if you plan to run the Firmware in the simavr
                            // simulator. Normally, you would not define this directly, but

--- a/cnc_ctrl_v1/GCode.h
+++ b/cnc_ctrl_v1/GCode.h
@@ -46,5 +46,6 @@ void  G38(const String&);
 void  setInchesToMillimetersConversion(float);
 extern int SpindlePowerControlPin;
 extern int ProbePin;
+extern int FAKE_SERVO_STATE;
 
 #endif

--- a/cnc_ctrl_v1/Motor.cpp
+++ b/cnc_ctrl_v1/Motor.cpp
@@ -113,7 +113,7 @@ void Motor::write(int speed, bool force){
     /*
     Sets motor speed from input. Speed = 0 is stopped, -255 is full reverse, 255 is full ahead. If force is true the motor attached state will be ignored
     */
-    if (_attachedState == 1 or force){
+    if ((_attachedState == 1 or force) and (FAKE_SERVO_STATE == 0)){
         speed = constrain(speed, -255, 255);
         _lastSpeed = speed; //saves speed for use in additive write
         bool forward = (speed > 0);

--- a/cnc_ctrl_v1/cnc_ctrl_v1.ino
+++ b/cnc_ctrl_v1/cnc_ctrl_v1.ino
@@ -35,6 +35,7 @@
 // TLE5206 version
 
 #include "Maslow.h"
+#include <EEPROM.h>
 
 // Define system global state structure
 system_t sys;
@@ -44,6 +45,9 @@ settings_t sysSettings;
 
 // Global realtime executor bitflag variable for setting various alarms.
 byte systemRtExecAlarm;  
+
+// Define global flag for FAKE_SERVO state
+int FAKE_SERVO_STATE = 0;
 
 // Define axes, it might be tighter to define these within the sys struct
 Axis leftAxis;
@@ -63,6 +67,12 @@ void setup(){
     Serial.println(F(" Detected"));
     sys.inchesToMMConversion = 1;
     sys.writeStepsToEEPROM = false;
+    FAKE_SERVO_STATE = EEPROM[ FAKE_SERVO ] & B00000001;
+   if (FAKE_SERVO_STATE == 0) {
+       Serial.println(F("FAKE_SERVO off"));
+   } else {
+       Serial.println(F("FAKE_SERVO on"));
+   }
     settingsLoadFromEEprom();
     sys.feedrate = sysSettings.maxFeed / 2.0;
     setupAxes();


### PR DESCRIPTION
FAKE_SERVO mode is useful for testing firmware and GC changes, or troublesome gcode files without needing to run the router around the board. It can be used on a Mega/motorControl pair with no motors attached.

  Use: 'B99 ON' turns FAKE_SERVO mode on, 'B99' with anything other than 'ON' (or nothing) turns it off.
  The current state of FAKE_SERVO is reported at startup and when it changes.
  The state is saved in EEPROM to persist over restarts, but is set off when the EEPROM is wiped, so off is the default state. 
  During FAKE_SERVO mode, the motors do not run. Instead computePID() spoofs the encoder value sent to the PID using a value that is +- 10% of the expected destination value. The cursor on the GC screen tracks the progress of the spoofed encoder values.

Files changed:
 cnc_ctrl_v1.ino:
 - add global flag to signal Axis::computePID() and Motor::write()
 - check for saved state at startup and report it

 Gcode.cpp:
 - add 'B99 ' command
 - - if the line contains 'ON' set FAKE_SERVO_STATE otherwise clear it
 - - report the state
 - - save the value of FAKE_SERVO_STATE in the high byte of EEPROM to persiste over restarts
 - - note that Setings::settingsWipe(SETTINGS_RESTORE_ALL) writes '0' to that location, which turns FAKE_SERVO off

 Axis.cpp:
 - at start of Axis::computePID(), check 'if (FAKE_SERVO_STATE != 0)' to determine whether to fake the encoder change. The check adds very few microseconds to this importrant function.

 Motor.cpp:
 - at the start of Motor::write() add a check for (FAKE_SERVO_STATE == 0) to determine whether to set the speed of the motor. This check adds only a few microseconds. Adding this check keeps the motors inoperative dureing FAKE_SERVO mode.

Thanks for contributing to The Maslow Firmware! You rock.

Please let the community know some basic information about this pull request.

## What does this pull request do?
This adds a feature.

## Does this firmware change affect kinematics or any part of the calibration process?
No, it does not change the kinematics.
### a) If so, does this change require recalibration?
It does not need recalibration.
### b) If so, is there an option for user to opt-out of the change until ready for recalibration? If not, explain why this is not possible.
The default state is off.
### c) Has the calibration model in gc/hc/wc been updated to agree with firmware change?
The change does not affect these, no changes are needed,
### d) Has this PR been tested on actual machine and/or in fake servo mode (indicate which or both)?
The PR has been tested on an actual machine _and_ in fake servo mode 😁.

## How can this pull request be tested?
Please provide detailed steps about how to test this pull request.
Create two macros: 'B99' and B99 ON'
Start GC and connect, note the line 'FAKE_SERVO off' on the screen.
Test for correct motor operation.
Use the 'B99 ON' macro, note the line 'FAKE_SERVO on'
Test that the cursor moves on the screen as expected but the motors stay quiet.
Disconnect the serial connection and reconnect to demonstrate that the state of FAKE_SERVO persists over a restart.
Use the 'B99' macro, note the line 'FAKE_SERVO off'
Test for correct motor operation.

