### PR TITLE
tighten up FAKE_SERVO access

### DIFF
--- a/cnc_ctrl_v1/Axis.cpp
+++ b/cnc_ctrl_v1/Axis.cpp
@@ -85,7 +85,7 @@ void   Axis::setSteps(const long& steps){
 
 void   Axis::computePID(){
     
-      if (FAKE_SERVO_STATE != 0) {
+      if (FAKE_SERVO_STATE == FAKE_SERVO_PERMITTED) {
           if (motorGearboxEncoder.motor.attached()){
             // Adds up to 10% error just to simulate servo noise
             double rpm = (-1 * _pidOutput) * random(90, 110) / 100;

--- a/cnc_ctrl_v1/Config.h
+++ b/cnc_ctrl_v1/Config.h
@@ -25,7 +25,8 @@
                            // LOOPINTERVAL tuning
 #define KINEMATICSDBG 0    // set to 1 for additional kinematics debug messaging
 
-#define FAKE_SERVO 4095    // store the state of FAKE_SERVO in EEPROM[ 4095 ] to preserve
+#define FAKE_SERVO_PERMITTED 42 // store this value
+#define FAKE_SERVO 4095    // in EEPROM[ 4095 ] to preserve
                            // the state of FAKE_SERVO mode over resets.
                            // Use 'B99 ON' to turn FAKE_SERVO mode on and set EEPROM[ 4095 ] to '1',
                            // 'B99' with no parameter, or any parameter other than 'ON' 

--- a/cnc_ctrl_v1/GCode.cpp
+++ b/cnc_ctrl_v1/GCode.cpp
@@ -376,23 +376,23 @@ byte  executeBcodeLine(const String& gcodeLine){
         // updating the encoder steps even if no servo is connected.
         // Useful for testing on an arduino only (e.g. without motors).
         // The status of FAKE_SERVO mode is stored in EEPROM[ 4095 ] 
-        // to persist between resets. Tthat byte is set to '1' when FAKE_SERVO
+        // to persist between resets. That byte is set to 'FAKE_SERVO_PERMITTED' when FAKE_SERVO
         // is on, '0' when off. settingsWipe(SETTINGS_RESTORE_ALL) clears the
         // EEPROM to '0', sothat stores '0' at EEPROM[ 4095 ] as well.
         if(gcodeLine.substring(0, 3) == "B99") {
         int letterO = gcodeLine.indexOf('O');
         int letterN = gcodeLine.indexOf('N');
         if ((letterO != -1) && (letterN != -1)) {
-          EEPROM[ FAKE_SERVO ] = 1;
-          FAKE_SERVO_STATE = 1;
+          EEPROM[ FAKE_SERVO ] = FAKE_SERVO_PERMITTED;
+          FAKE_SERVO_STATE = FAKE_SERVO_PERMITTED;
         } else {
           EEPROM[ FAKE_SERVO ] = 0;
           FAKE_SERVO_STATE = 0;
         }
-        if (FAKE_SERVO_STATE == 0) {
-          Serial.println(F("FAKE_SERVO off"));
-        } else {
+        if (FAKE_SERVO_STATE == FAKE_SERVO_PERMITTED) {
           Serial.println(F("FAKE_SERVO on"));
+        } else {
+          Serial.println(F("FAKE_SERVO off"));
         }
         return(STATUS_OK);
      }

--- a/cnc_ctrl_v1/Motor.cpp
+++ b/cnc_ctrl_v1/Motor.cpp
@@ -113,7 +113,7 @@ void Motor::write(int speed, bool force){
     /*
     Sets motor speed from input. Speed = 0 is stopped, -255 is full reverse, 255 is full ahead. If force is true the motor attached state will be ignored
     */
-    if ((_attachedState == 1 or force) and (FAKE_SERVO_STATE == 0)){
+    if ((_attachedState == 1 or force) and (FAKE_SERVO_STATE != FAKE_SERVO_PERMITTED)){
         speed = constrain(speed, -255, 255);
         _lastSpeed = speed; //saves speed for use in additive write
         bool forward = (speed > 0);

--- a/cnc_ctrl_v1/cnc_ctrl_v1.ino
+++ b/cnc_ctrl_v1/cnc_ctrl_v1.ino
@@ -67,12 +67,13 @@ void setup(){
     Serial.println(F(" Detected"));
     sys.inchesToMMConversion = 1;
     sys.writeStepsToEEPROM = false;
-    FAKE_SERVO_STATE = EEPROM[ FAKE_SERVO ] & B00000001;
-   if (FAKE_SERVO_STATE == 0) {
-       Serial.println(F("FAKE_SERVO off"));
-   } else {
-       Serial.println(F("FAKE_SERVO on"));
-   }
+    FAKE_SERVO_STATE = EEPROM[ FAKE_SERVO ];
+    if (FAKE_SERVO_STATE == FAKE_SERVO_PERMITTED) { // only this value is accepted
+        Serial.println(F("FAKE_SERVO on"));         // to turn this on
+    } else {
+        Serial.println(F("FAKE_SERVO off"));        // otherwise 
+        EEPROM[ FAKE_SERVO ] = 0;                   // force it to the 'off' value
+    }
     settingsLoadFromEEprom();
     sys.feedrate = sysSettings.maxFeed / 2.0;
     setupAxes();


### PR DESCRIPTION
 - define a specific number value to indicate FAKE_SERVO as active in Config.h
 - in cnc_ctrl_v1 on startup, check the contents of EEPROM[ 4095 ] for that special value, if found enter FAKE_SERVO but if any othe value is found store a '0' there and indicate that FAKE_SERVO is 'off'
 - change the logic in Axis::computePID() and Motor::write() to check for the specific value ranther than non-zero.

## What does this pull request do?
Does it add a new feature or fix a bug?
This PR addresses issue #531 

## Does this firmware change affect kinematics or any part of the calibration process?
No, it does not change kinematics
### a) If so, does this change require recalibration?
It does not require recalibration.
### b) If so, is there an option for user to opt-out of the change until ready for recalibration? If not, explain why this is not possible.
### c) Has the calibration model in gc/hc/wc been updated to agree with firmware change?
### d) Has this PR been tested on actual machine and/or in fake servo mode (indicate which or both)?
Yes, it has been tested on an actual machine.

## How can this pull request be tested?
Please provide detailed steps about how to test this pull request.
 - Start GC and connect; note the line 'FAKE_SERVO OFF'
 - try to turn FAKE_SERVO on using 'ctrl'-f; nothing happens
 - change Settings/GroundControl/'FAKE_SERVO allowed' from 'Not allowed' to 'Allowed'
 - close the settings pane, quit GC and re-open it.
 - after connecting, observe the line 'FAKE_SERVO OFF'
 - enable FAKE_SERVO mode using 'ctrl'-f
 - note the line 'FAKE_SERVO ON'
 - quit GC and re-open it
 - after connecting, observe the line 'FAKE_SERVO ON'
 - change Setting/GroundControl/FAKE_SERVO_allowed to 'Not allowed'
 - confirm that FAKE_SERVO can be turned off using the 'f' key, note the line 'FAKE_SERVO OFF'
 - confirm that 'ctrl'-f does not turn FAKE_SERVO on

