### PR TITLE
remove characters within a comment

### DIFF
--- a/cnc_ctrl_v1/GCode.cpp
+++ b/cnc_ctrl_v1/GCode.cpp
@@ -566,6 +566,9 @@ void  sanitizeCommandString(String& cmdString){
                 cmdString.remove(pos, 1);
                 if (line_flags & LINE_FLAG_COMMENT_PARENTHESES) { line_flags &= ~(LINE_FLAG_COMMENT_PARENTHESES); }
             }
+           else {
+                cmdString.remove(pos, 1);
+            }
         }
         else {
             if (cmdString[pos] < ' ') {


### PR DESCRIPTION
Remove comment characters between parentheses. GC removes all comments, but WebControl passes them to the firmware. Without this patch, the Arduino reboots when WC sends a line that contains a gcode command and a comment.

## What does this pull request do? - Removes the characters of a comment that fall between the parentheses.
Does it add a new feature or fix a bug? - It fixes a bug that made gcode files with comments on lines with gcode commands cause the Arduino to reboot.

## Does this firmware change affect kinematics or any part of the calibration process? - no
### a) If so, does this change require recalibration? - no
### b) If so, is there an option for user to opt-out of the change until ready for recalibration? If not, explain why this is not possible. - NA
### c) Has the calibration model in gc/hc/wc been updated to agree with firmware change? - NA
### d) Has this PR been tested on actual machine and/or in fake servo mode (indicate which or both)? - yes, both

## How can this pull request be tested? Please provide detailed steps about how to test this pull request.

Because GC strips comments before sending lines to the Firmware, testing needs to be done in WebControl.
Using WebControl, this gcode snippet will run correctly without the patch:
```
G90
G20
G0 X0 Y0
G1 X1 Y1
G1 X0 Y0
```
Using WebControl, this snippet will cause a 'Connection Lost' error and require WC to be restarted.
```
G90
G20
G0 X0 Y0
G1 X1 Y1 ( comment )
G1 X0 Y0
```
After applying the patch, the second snippet runs as expected.

