### PR TITLE
Do not perform Z axis movement on G2 if Z is not specified in gcode line

### DIFF
--- a/cnc_ctrl_v1/GCode.cpp
+++ b/cnc_ctrl_v1/GCode.cpp
@@ -20,6 +20,7 @@ Copyright 2014-2017 Bar Smith*/
 
 #include "Maslow.h"
 #include <EEPROM.h>
+#include "math.h"
 
 maslowRingBuffer incSerialBuffer;
 String readyCommandString = "";  //KRK why is this a global?
@@ -779,7 +780,8 @@ void G2(const String& readString, int G2orG3){
 
     float X2      = sys.inchesToMMConversion*extractGcodeValue(readString, 'X', X1/sys.inchesToMMConversion);
     float Y2      = sys.inchesToMMConversion*extractGcodeValue(readString, 'Y', Y1/sys.inchesToMMConversion);
-    float Z2      = sys.inchesToMMConversion*extractGcodeValue(readString, 'Z', Z1/sys.inchesToMMConversion);
+    // Read target Z position from gcode. If it is not specified then set it to NAN so it will not be used.
+    float Z2      = sys.inchesToMMConversion*extractGcodeValue(readString, 'Z', NAN);
     float I       = sys.inchesToMMConversion*extractGcodeValue(readString, 'I', 0.0);
     float J       = sys.inchesToMMConversion*extractGcodeValue(readString, 'J', 0.0);
     sys.feedrate      = sys.inchesToMMConversion*extractGcodeValue(readString, 'F', sys.feedrate/sys.inchesToMMConversion);
@@ -789,6 +791,10 @@ void G2(const String& readString, int G2orG3){
 
     sys.feedrate = constrain(sys.feedrate, 1, sysSettings.maxFeed);   //constrain the maximum feedrate, 35ipm = 900 mmpm
 
+    // If there is no target Z (Z2) then set Z1 to be NAN so it is not used.
+    if (isnan(Z2)) {
+      Z1 = Z2;
+    }
     if (G2orG3 == 2){
         arc(X1, Y1, Z1, X2, Y2, Z2, centerX, centerY, sys.feedrate, CLOCKWISE);
     }


### PR DESCRIPTION
## What does this pull request do?
- Do not perform Z axis movement on G2 if Z is not specified in gcode line.
- Set Z1 and Z2 to NAN if not provided. 
- Update arc() to deal with NAN Z. 
- Make Z calculations happen the same way as X&Y before movementUpdate().
- Add Z end move same as X & Y.

## Does it add a new feature or fix a bug?
Removes unnecessary z axis calculation and faulty movement. This fixes a problem in with Z axis not reaching target depth when G2 is executed as zxais.read was getting current z position whilst it was still in motion and using that for the G2 Z. This code lets the previous Z movement complete. 

## Does this firmware change affect kinematics or any part of the calibration process?
No.
#### a) If so, does this change require recalibration?
#### b) If so, is there an option for user to opt-out of the change until ready for recalibration? If not, explain why this is not possible.
#### c) Has the calibration model in gc/hc/wc been updated to agree with firmware change?
#### d) Has this PR been tested on actual machine and/or in fake servo mode (indicate which or both)?
Fake servo only. Will hopefully test on actual machine this weekend.

## How can this pull request be tested?

### G2 code without Z
```
G0 G40 G90  
G21  
G0 X0 Y0 Z0  
G1 Z-8  
G2 X37.93360 Y5.515 I43.2022 J129.306
G0 Z0  
```

### G2 code with Z
```
G0 G40 G90 G17  
G21  
G0 X0 Y0 Z0  
G1 Z-8  
G2 X37.93360 Y5.515 I43.2022 J129.306 Z-12 
G0 Z0  
```