### PR TITLE
TB6643 v1.5 support

### DIFF
--- a/cnc_ctrl_v1/Axis.cpp
+++ b/cnc_ctrl_v1/Axis.cpp
@@ -302,19 +302,24 @@ void   Axis::test(){
     //print something to prevent the connection from timing out
     Serial.print(F("<Idle,MPos:0,0,0,WPos:0.000,0.000,0.000>"));
     
-    int i = 0;
+ 
     double encoderPos = motorGearboxEncoder.encoder.read(); //record the position now
-    
-    //move the motor
-    motorGearboxEncoder.motor.directWrite(255);
-    while (i < 1000){
-        i++;
-        maslowDelay(1);
-        if (sys.stop){return;}
+
+
+    //ramp up to full speed
+    for (int ramp = 1 ; ramp <= 255; ramp += 15) {
+    motorGearboxEncoder.motor.directWrite(ramp);
+    maslowDelay(30);
+    if (sys.stop){return;}
     }
-    //stop the motor
-    motorGearboxEncoder.motor.directWrite(0);
-    
+    maslowDelay(3000);
+    //ramp down to stop
+    for (int ramp = 241 ; ramp >= 1; ramp += -15) {
+    motorGearboxEncoder.motor.directWrite(ramp);
+    maslowDelay(30);
+    if (sys.stop){return;}
+    }
+   //maslowDelay(300);
     //check to see if it moved
     if(encoderPos - motorGearboxEncoder.encoder.read() > 500){
         Serial.println(F("Direction 1 - Pass"));
@@ -328,16 +333,19 @@ void   Axis::test(){
     Serial.print(F("<Idle,MPos:0,0,0,WPos:0.000,0.000,0.000>"));
     
     //move the motor in the other direction
-    i = 0;
-    motorGearboxEncoder.motor.directWrite(-255);
-    while (i < 1000){
-        i++;
-        maslowDelay(1);
-        if (sys.stop){return;}
+    for (int ramp = -1 ; ramp >= -255; ramp += -15) {
+    motorGearboxEncoder.motor.directWrite(ramp);
+    maslowDelay(30);
+    if (sys.stop){return;}  
     }
-    //stop the motor
+    maslowDelay(2200); // ensure the motor spins at least one full revolution 1700
+    for (int ramp = -241 ; ramp <= -1; ramp += 15) {
+    motorGearboxEncoder.motor.directWrite(ramp);
+    maslowDelay(30);
+    if (sys.stop){return;}
+    }
+    maslowDelay(300);
     motorGearboxEncoder.motor.directWrite(0);
-    
     //check to see if it moved
     if(encoderPos - motorGearboxEncoder.encoder.read() < -500){
         Serial.println(F("Direction 2 - Pass"));

--- a/cnc_ctrl_v1/Motor.cpp
+++ b/cnc_ctrl_v1/Motor.cpp
@@ -46,8 +46,17 @@ int  Motor::setupMotor(const int& pwmPin, const int& pin1, const int& pin2){
     
  //stop the motor
     digitalWrite(_pin1,    LOW);
-    digitalWrite(_pin2,    LOW) ;
+    digitalWrite(_pin2,    LOW);
     
+ } else if (TB6643 == true){
+  //set pinmodes
+    pinMode(_pin1,     OUTPUT);
+    pinMode(_pin2,     OUTPUT);
+
+  //stop the motor
+    digitalWrite(_pin1,    HIGH);
+    digitalWrite(_pin2,    HIGH);
+      
   } else if (TLE9201 == true) {
   //set pinmodes
     pinMode(_pwmPin,   OUTPUT);
@@ -78,6 +87,10 @@ void Motor::attach(){
 void Motor::detach(){
     if (_attachedState != 0) {
         if (TLE5206 == true) {
+          //stop the motor
+          digitalWrite(_pin1,    LOW);
+          digitalWrite(_pin2,    LOW) ; 
+        } else if (TB6643 == true){
           //stop the motor
           digitalWrite(_pin1,    LOW);
           digitalWrite(_pin2,    LOW) ;
@@ -116,13 +129,13 @@ void Motor::write(int speed, bool force){
     if ((_attachedState == 1 or force) and (FAKE_SERVO_STATE != FAKE_SERVO_PERMITTED)){
         speed = constrain(speed, -255, 255);
         _lastSpeed = speed; //saves speed for use in additive write
-        bool forward = (speed > 0);
+        bool forward = (speed >= 0);
         speed = abs(speed); //remove sign from input because direction is set by control pins on H-bridge
 
         bool usePin1 = ((_pin1 != 4) && (_pin1 != 13) && (_pin1 != 11) && (_pin1 != 12)); // avoid PWM using timer0 or timer1
         bool usePin2 = ((_pin2 != 4) && (_pin2 != 13) && (_pin2 != 11) && (_pin2 != 12)); // avoid PWM using timer0 or timer1
         bool usepwmPin = ((TLE5206 == false) && (_pwmPin != 4) && (_pwmPin != 13) && (_pwmPin != 11) && (_pwmPin != 12)); // avoid PWM using timer0 or timer1       
-        if (!(TLE5206 || TLE9201)) { // L298 boards
+        if (!(TLE5206 || TLE9201 || TB6643)) { // L298 boards
             if (forward){
                 if (usepwmPin){
                     digitalWrite(_pin1 , HIGH );
@@ -159,7 +172,7 @@ void Motor::write(int speed, bool force){
             }
         } 
         else if (TLE5206)  {
-            speed = constrain(speed, 0, 254); // avoid issue when PWM value is 255
+            //speed = constrain(speed, 0, 254); // avoid issue when PWM value is 255
             if (forward) {
                 if (speed > 0) {
                     if (usePin2) {
@@ -186,7 +199,21 @@ void Motor::write(int speed, bool force){
                 }
             }
         }
-        else if (TLE9201) {
+        else if (TB6643){ // EBS v1.5
+             if (forward) {
+                if (speed > 0) {
+                        analogWrite(_pin1 , speed);
+                        digitalWrite(_pin2 , LOW); 
+                } else { // speed = 0 brake
+                    digitalWrite(_pin1 , HIGH);
+                    digitalWrite(_pin2 , HIGH);
+                }
+            } else { // reverse     
+                    digitalWrite(_pin1 , LOW);
+                    analogWrite(_pin2 , speed);   
+                  
+            }
+        } else if (TLE9201) {
             int dirPin     = _pin1;
             int enablePin  = _pin2;
             const int TOP  = 1;

--- a/cnc_ctrl_v1/Motor.h
+++ b/cnc_ctrl_v1/Motor.h
@@ -51,6 +51,7 @@
     };
     extern bool TLE5206;
     extern bool TLE9201;
+    extern bool TB6643;
     extern int ENA;
     extern int ENB;
     extern int ENC;

--- a/cnc_ctrl_v1/Settings.cpp
+++ b/cnc_ctrl_v1/Settings.cpp
@@ -77,7 +77,7 @@ void settingsReset() {
     sysSettings.originalChainLength = 1651;   // int originalChainLength;
     sysSettings.encoderSteps = 8113.73; // float encoderSteps;
     sysSettings.distPerRot = 63.5;   // float distPerRot;
-    sysSettings.maxFeed = 700;   // int maxFeed;
+    sysSettings.maxFeed = 900;   // int maxFeed;
     sysSettings.zAxisAttached = true;   // zAxisAttached;
     sysSettings.spindleAutomateType = NONE;  // bool spindleAutomate;
     sysSettings.maxZRPM = 12.60;  // float maxZRPM;

--- a/cnc_ctrl_v1/cnc_ctrl_v1.ino
+++ b/cnc_ctrl_v1/cnc_ctrl_v1.ino
@@ -33,6 +33,7 @@
 
 // TLE9201 version
 // TLE5206 version
+// TB6643 version
 
 #include "Maslow.h"
 #include <EEPROM.h>
@@ -64,6 +65,7 @@ void setup(){
     Serial.print(getPCBVersion());
     if (TLE5206 == true) { Serial.print(F(" TLE5206 ")); }
     if (TLE9201 == true) { Serial.print(F(" TLE9201 ")); }
+    if (TB6643 == true)  { Serial.print(F(" TB6643 ")); }
     Serial.println(F(" Detected"));
     sys.inchesToMMConversion = 1;
     sys.writeStepsToEEPROM = false;
@@ -114,9 +116,10 @@ void loop(){
     initGCode();
     if (sys.stop){               // only called on sys.stop to prevent stopping
         initMotion();            // on USB disconnect.  Might consider removing 
-        setSpindlePower(false);  // this restriction for safety if we are 
-    }                            // comfortable that USB disconnects are
-                                 // not a common occurrence anymore
+        setSpindlePower(false);  // this restriction for safety if we are comfortable that USB disconnects are not a common occurrence anymore
+        laserOff();          // 
+    }                             
+                                 
     kinematics.init();
     
     // Let's go!


### PR DESCRIPTION
1- Added support for EBS shield TB6643 v1.5
2- Added acceleration control for "test motors/encoders" to avoid triggering the TLE5206/TB6643 overcurrent alarm/cut-off while testing (https://forums.maslowcnc.com/t/motor-wont-stop-turning/16680/8)
3- Fix for a small bug in Motor.cpp line 119 which prevented the brake for being applied.
4- Added laserOff to sys.stop and systemReset for safety
5- maxFeed bumped up to 900 (~35ipm)

